### PR TITLE
feat: config overlay improvements - field status fix, monitor grouping, layout diagram

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -112,6 +112,13 @@ pub struct Config {
     #[dynamic(default)]
     pub dpi_by_screen: HashMap<String, f64>,
 
+    // --- weezterm remote features ---
+    /// Per-monitor configuration overrides. When the terminal window
+    /// moves onto a matching monitor, the specified settings (e.g.
+    /// color_scheme) are applied. When it leaves, they are reverted.
+    #[dynamic(default)]
+    pub monitor_overrides: Vec<crate::monitor::MonitorOverride>,
+    // --- end weezterm remote features ---
     /// The baseline font to use
     #[dynamic(default)]
     pub font: TextStyle,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1149,12 +1149,11 @@ impl Config {
                         .set_name(p.to_string_lossy())
                         .eval_async(),
                 )?;
-                let config = Config::apply_overrides_to(&lua, config)?;
-                let config = Config::apply_overrides_obj_to(&lua, config, overrides)?;
-
                 // --- weezterm remote features ---
-                // Capture which top-level keys are present in the Lua config table.
-                // This tells us which fields the user explicitly set (even to defaults).
+                // Capture which top-level keys are present in the Lua config table
+                // BEFORE overrides are applied. This ensures lua_set_fields only
+                // contains keys the user explicitly set in their Lua config, not
+                // keys injected by window-level overrides (e.g. config overlay).
                 if let mlua::Value::Table(ref tbl) = config {
                     let mut keys = std::collections::HashSet::new();
                     for pair in tbl.clone().pairs::<mlua::Value, mlua::Value>() {
@@ -1167,6 +1166,9 @@ impl Config {
                     crate::set_lua_config_keys(keys);
                 }
                 // --- end weezterm remote features ---
+
+                let config = Config::apply_overrides_to(&lua, config)?;
+                let config = Config::apply_overrides_obj_to(&lua, config, overrides)?;
 
                 cfg = Config::from_lua(config, &lua).with_context(|| {
                     format!(

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -22,6 +22,7 @@ use wezterm_term::UnicodeVersion;
 
 // --- weezterm remote features ---
 pub mod branding;
+pub mod monitor;
 // --- end weezterm remote features ---
 mod background;
 mod bell;
@@ -65,6 +66,10 @@ pub use units::*;
 pub use unix::*;
 pub use version::*;
 pub use wsl::*;
+
+// --- weezterm remote features ---
+pub use monitor::*;
+// --- end weezterm remote features ---
 
 type ErrorCallback = fn(&str);
 

--- a/config/src/monitor.rs
+++ b/config/src/monitor.rs
@@ -1,0 +1,27 @@
+// --- weezterm remote features ---
+use serde::{Deserialize, Serialize};
+use wezterm_dynamic::{FromDynamic, ToDynamic};
+
+/// Per-monitor configuration overrides.
+///
+/// When the terminal window moves onto a monitor whose name matches
+/// `monitor`, the specified overrides (e.g. `color_scheme`) are applied.
+/// When the window leaves that monitor, the overrides are removed and
+/// the user's base configuration is restored.
+///
+/// Monitor names are the same strings visible in `dpi_by_screen`:
+/// - Windows: friendly display name from QueryDisplayConfig (e.g. "DELL U2720Q")
+/// - macOS:  NSScreen localizedName (e.g. "Color LCD")
+/// - X11:   RANDR output name (e.g. "DP-1")
+/// - Wayland: wlr_output name
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, FromDynamic, ToDynamic)]
+pub struct MonitorOverride {
+    /// The monitor name to match.
+    pub monitor: String,
+
+    /// If set, use this color scheme when the window is on this monitor.
+    #[dynamic(default)]
+    pub color_scheme: Option<String>,
+    // Future fields: font_size, opacity, background, window_background_opacity, etc.
+}
+// --- end weezterm remote features ---

--- a/wezterm-gui/src/overlay/config_overlay/data.rs
+++ b/wezterm-gui/src/overlay/config_overlay/data.rs
@@ -998,6 +998,19 @@ pub struct MonitorOverrideEntry {
     pub color_scheme: Option<String>,
     /// Whether this monitor is the one the current window is on.
     pub is_current: bool,
+    /// Whether this entry is expanded in the overlay UI.
+    pub expanded: bool,
+    /// Screen position and size in pixels (for layout diagram).
+    pub screen_rect: Option<MonitorRect>,
+}
+
+/// Screen rectangle for layout diagram rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MonitorRect {
+    pub x: isize,
+    pub y: isize,
+    pub width: isize,
+    pub height: isize,
 }
 
 /// Build MonitorOverrideEntry list from the current system monitors
@@ -1006,23 +1019,31 @@ pub struct MonitorOverrideEntry {
 /// This must be called from code that has access to the screen list
 /// (typically the GUI thread). Pass the result to the config overlay.
 pub fn monitors_from_config_with_screens(
-    screens: &[String],
+    screen_info: &std::collections::HashMap<String, window::screen::ScreenInfo>,
     current_screen: Option<&str>,
 ) -> Vec<MonitorOverrideEntry> {
     let config = config::configuration();
 
     let mut entries: Vec<MonitorOverrideEntry> = Vec::new();
-    for name in screens {
+    for (name, info) in screen_info {
         let color_scheme = config
             .monitor_overrides
             .iter()
             .find(|mo| &mo.monitor == name)
             .and_then(|mo| mo.color_scheme.clone());
 
+        let rect = info.rect;
         entries.push(MonitorOverrideEntry {
             monitor_name: name.clone(),
             color_scheme,
             is_current: current_screen == Some(name.as_str()),
+            expanded: false,
+            screen_rect: Some(MonitorRect {
+                x: rect.origin.x,
+                y: rect.origin.y,
+                width: rect.size.width,
+                height: rect.size.height,
+            }),
         });
     }
 
@@ -1033,6 +1054,8 @@ pub fn monitors_from_config_with_screens(
                 monitor_name: mo.monitor.clone(),
                 color_scheme: mo.color_scheme.clone(),
                 is_current: false,
+                expanded: false,
+                screen_rect: None,
             });
         }
     }

--- a/wezterm-gui/src/overlay/config_overlay/data.rs
+++ b/wezterm-gui/src/overlay/config_overlay/data.rs
@@ -159,6 +159,9 @@ pub enum Section {
     Input,
     SshAndDomains,
     Rendering,
+    // --- weezterm remote features ---
+    Monitors,
+    // --- end weezterm remote features ---
 }
 
 impl Section {
@@ -172,6 +175,9 @@ impl Section {
             Section::Input => "Input",
             Section::SshAndDomains => "SSH & Domains",
             Section::Rendering => "Rendering",
+            // --- weezterm remote features ---
+            Section::Monitors => "Monitors",
+            // --- end weezterm remote features ---
         }
     }
 }
@@ -210,6 +216,9 @@ pub fn get_sections() -> Vec<Section> {
         Section::Input,
         Section::SshAndDomains,
         Section::Rendering,
+        // --- weezterm remote features ---
+        Section::Monitors,
+        // --- end weezterm remote features ---
     ]
 }
 
@@ -978,6 +987,75 @@ pub fn to_config_ssh_domain(dom: &SshDomainConfig) -> config::SshDomain {
         ..Default::default()
     }
 }
+
+// --- weezterm remote features ---
+/// A monitor override entry for the config overlay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonitorOverrideEntry {
+    /// The monitor name (from ScreenInfo).
+    pub monitor_name: String,
+    /// The assigned color scheme, or None for "use default".
+    pub color_scheme: Option<String>,
+    /// Whether this monitor is the one the current window is on.
+    pub is_current: bool,
+}
+
+/// Build MonitorOverrideEntry list from the current system monitors
+/// and the config's monitor_overrides settings.
+///
+/// This must be called from code that has access to the screen list
+/// (typically the GUI thread). Pass the result to the config overlay.
+pub fn monitors_from_config_with_screens(
+    screens: &[String],
+    current_screen: Option<&str>,
+) -> Vec<MonitorOverrideEntry> {
+    let config = config::configuration();
+
+    let mut entries: Vec<MonitorOverrideEntry> = Vec::new();
+    for name in screens {
+        let color_scheme = config
+            .monitor_overrides
+            .iter()
+            .find(|mo| &mo.monitor == name)
+            .and_then(|mo| mo.color_scheme.clone());
+
+        entries.push(MonitorOverrideEntry {
+            monitor_name: name.clone(),
+            color_scheme,
+            is_current: current_screen == Some(name.as_str()),
+        });
+    }
+
+    // Also include any configured monitors that aren't currently connected
+    for mo in &config.monitor_overrides {
+        if !entries.iter().any(|e| e.monitor_name == mo.monitor) {
+            entries.push(MonitorOverrideEntry {
+                monitor_name: mo.monitor.clone(),
+                color_scheme: mo.color_scheme.clone(),
+                is_current: false,
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| a.monitor_name.cmp(&b.monitor_name));
+    entries
+}
+
+/// Convert MonitorOverrideEntry list to config::MonitorOverride list
+/// (only entries with at least one override set).
+pub fn to_config_monitor_overrides(
+    entries: &[MonitorOverrideEntry],
+) -> Vec<config::MonitorOverride> {
+    entries
+        .iter()
+        .filter(|e| e.color_scheme.is_some())
+        .map(|e| config::MonitorOverride {
+            monitor: e.monitor_name.clone(),
+            color_scheme: e.color_scheme.clone(),
+        })
+        .collect()
+}
+// --- end weezterm remote features ---
 
 #[cfg(test)]
 mod test {

--- a/wezterm-gui/src/overlay/config_overlay/mod.rs
+++ b/wezterm-gui/src/overlay/config_overlay/mod.rs
@@ -18,16 +18,22 @@ mod render;
 pub mod theme;
 
 pub use data::{FieldDef, FieldKind, Section, SshDomainConfig};
+// --- weezterm remote features ---
+pub use data::MonitorOverrideEntry;
+// --- end weezterm remote features ---
 
 /// Result returned by the config overlay to the caller.
 #[derive(Debug, Clone)]
 pub enum ConfigOverlayAction {
     /// User closed the overlay without saving.
     Close,
-    /// User chose to save proposals (includes domain changes).
+    /// User chose to save proposals (includes domain changes and monitor overrides).
     Save {
         proposals: HashMap<String, Value>,
         ssh_domains: Vec<SshDomainConfig>,
+        // --- weezterm remote features ---
+        monitor_overrides: Vec<MonitorOverrideEntry>,
+        // --- end weezterm remote features ---
     },
     /// User chose to preview proposals (apply as window overrides).
     Preview(HashMap<String, Value>),
@@ -111,6 +117,16 @@ struct OverlayState {
     adding_domain: Option<SshDomainConfig>,
     /// Whether domain_entries has been modified.
     domains_dirty: bool,
+    // --- weezterm remote features ---
+    /// Monitor override entries.
+    monitor_entries: Vec<MonitorOverrideEntry>,
+    /// Selected monitor index (for the Monitors section).
+    selected_monitor: usize,
+    /// Whether monitor overrides have been modified.
+    monitors_dirty: bool,
+    /// Monitor scheme picker popup.
+    monitor_scheme_picker: Option<ColorSchemePicker>,
+    // --- end weezterm remote features ---
 }
 
 /// State for inline editing of a field value.
@@ -223,6 +239,12 @@ impl OverlayState {
             domain_entries,
             adding_domain: None,
             domains_dirty: false,
+            // --- weezterm remote features ---
+            monitor_entries: vec![],
+            selected_monitor: 0,
+            monitors_dirty: false,
+            monitor_scheme_picker: None,
+            // --- end weezterm remote features ---
         }
     }
 
@@ -381,6 +403,55 @@ impl OverlayState {
             }
         }
 
+        // --- weezterm remote features ---
+        // For Monitors section, show monitor override entries
+        if section == Section::Monitors {
+            for (idx, entry) in self.monitor_entries.iter().enumerate() {
+                if !filter_lower.is_empty()
+                    && !entry.monitor_name.to_lowercase().contains(&filter_lower)
+                {
+                    continue;
+                }
+
+                let scheme_display = entry
+                    .color_scheme
+                    .as_deref()
+                    .unwrap_or("(default)")
+                    .to_string();
+
+                let display_name = if entry.is_current {
+                    format!("▸ {}", entry.monitor_name)
+                } else {
+                    entry.monitor_name.clone()
+                };
+
+                rows.push(SettingRow {
+                    field_name: format!("__monitor_{}__", idx),
+                    display_name,
+                    current_value: scheme_display,
+                    proposed_value: None,
+                    status: FieldStatus::Editable,
+                    kind: FieldKind::ColorScheme,
+                    domain_header: None,
+                    domain_child: None,
+                });
+            }
+
+            if self.monitor_entries.is_empty() && filter_lower.is_empty() {
+                rows.push(SettingRow {
+                    field_name: "__no_monitors__".to_string(),
+                    display_name: "(no monitors detected)".to_string(),
+                    current_value: String::new(),
+                    proposed_value: None,
+                    status: FieldStatus::Inherited,
+                    kind: FieldKind::Text,
+                    domain_header: None,
+                    domain_child: None,
+                });
+            }
+        }
+        // --- end weezterm remote features ---
+
         rows
     }
 
@@ -446,6 +517,26 @@ impl OverlayState {
 
     /// Apply an edit: toggle bool, cycle enum, or accept inline text.
     fn apply_edit_for_field(&mut self, field_name: &str, new_value: Value) {
+        // --- weezterm remote features ---
+        // Intercept monitor override field names
+        if let Some(idx_str) = field_name
+            .strip_prefix("__monitor_")
+            .and_then(|s| s.strip_suffix("__"))
+        {
+            if let Ok(idx) = idx_str.parse::<usize>() {
+                if idx < self.monitor_entries.len() {
+                    let scheme = match &new_value {
+                        Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    };
+                    self.monitor_entries[idx].color_scheme = scheme;
+                    self.monitors_dirty = true;
+                    self.dirty = true;
+                }
+            }
+            return;
+        }
+        // --- end weezterm remote features ---
         self.proposals.insert(field_name.to_string(), new_value);
         self.dirty = true;
     }
@@ -666,6 +757,9 @@ pub fn run_config_overlay(
     default_values: HashMap<String, Value>,
     saved_proposals: HashMap<String, Value>,
     saved_domains: Vec<SshDomainConfig>,
+    // --- weezterm remote features ---
+    saved_monitors: Vec<MonitorOverrideEntry>,
+    // --- end weezterm remote features ---
     palette: config::Palette,
 ) -> anyhow::Result<ConfigOverlayAction> {
     let mut state = OverlayState::new(
@@ -674,6 +768,9 @@ pub fn run_config_overlay(
         saved_proposals,
         saved_domains,
     );
+    // --- weezterm remote features ---
+    state.monitor_entries = saved_monitors;
+    // --- end weezterm remote features ---
     let theme = theme::Theme::from_palette(&palette);
 
     term.set_raw_mode()?;
@@ -1236,6 +1333,9 @@ pub fn run_config_overlay(
                             return Ok(ConfigOverlayAction::Save {
                                 proposals: state.proposals.clone(),
                                 ssh_domains: state.overlay_domains(),
+                                // --- weezterm remote features ---
+                                monitor_overrides: state.monitor_entries.clone(),
+                                // --- end weezterm remote features ---
                             });
                         }
                     }
@@ -1469,11 +1569,13 @@ mod test {
                 remote_address: "host:22".to_string(),
                 ..Default::default()
             }],
+            monitor_overrides: vec![],
         };
         match action {
             ConfigOverlayAction::Save {
                 proposals,
                 ssh_domains,
+                ..
             } => {
                 assert!(proposals.is_empty());
                 assert_eq!(ssh_domains.len(), 1);

--- a/wezterm-gui/src/overlay/config_overlay/mod.rs
+++ b/wezterm-gui/src/overlay/config_overlay/mod.rs
@@ -73,6 +73,12 @@ pub(crate) struct SettingRow {
     pub domain_header: Option<DomainHeaderInfo>,
     /// If this is a domain child field, holds the domain index.
     pub domain_child: Option<usize>,
+    // --- weezterm remote features ---
+    /// If this is a monitor group header, holds the monitor index.
+    pub monitor_header: Option<MonitorHeaderInfo>,
+    /// If this is a monitor child field, holds the monitor index.
+    pub monitor_child: Option<usize>,
+    // --- end weezterm remote features ---
 }
 
 /// Info for a domain group header row.
@@ -82,6 +88,16 @@ pub(crate) struct DomainHeaderInfo {
     pub source: data::DomainSource,
     pub expanded: bool,
 }
+
+// --- weezterm remote features ---
+/// Info for a monitor group header row.
+#[derive(Debug, Clone)]
+pub(crate) struct MonitorHeaderInfo {
+    pub monitor_index: usize,
+    pub is_current: bool,
+    pub expanded: bool,
+}
+// --- end weezterm remote features ---
 
 /// Sentinel row type for "Add SSH Domain..." action.
 const ADD_DOMAIN_FIELD_NAME: &str = "__add_ssh_domain__";
@@ -103,6 +119,9 @@ struct OverlayState {
     default_values: HashMap<String, Value>,
     /// Fields that the Lua config explicitly set (even if to defaults).
     lua_set_fields: std::collections::HashSet<String>,
+    /// Keys from the saved config-overlay.json proposals — used to distinguish
+    /// overlay-set fields from genuinely Lua-set fields.
+    overlay_keys: std::collections::HashSet<String>,
     field_defs: Vec<FieldDef>,
     dirty: bool,
     /// Inline edit mode: field name + buffer
@@ -126,6 +145,9 @@ struct OverlayState {
     monitors_dirty: bool,
     /// Monitor scheme picker popup.
     monitor_scheme_picker: Option<ColorSchemePicker>,
+    /// Suppress the first mouse click to avoid passthrough from the overlay
+    /// that opened us (e.g. command palette).
+    ignore_first_mouse: bool,
     // --- end weezterm remote features ---
 }
 
@@ -199,6 +221,11 @@ impl OverlayState {
             proposals.insert(k, v);
         }
 
+        // Track which keys came from the saved overlay JSON so we can
+        // distinguish them from keys genuinely set by the user's Lua config.
+        let overlay_keys: std::collections::HashSet<String> =
+            proposals.keys().cloned().collect();
+
         // Build domain entries: Lua-sourced (read-only) + overlay-sourced (editable)
         let mut domain_entries = data::domains_from_config();
         for saved_dom in saved_domains {
@@ -231,6 +258,7 @@ impl OverlayState {
             effective_values,
             default_values,
             lua_set_fields,
+            overlay_keys,
             field_defs,
             dirty: false,
             inline_edit: None,
@@ -244,6 +272,7 @@ impl OverlayState {
             selected_monitor: 0,
             monitors_dirty: false,
             monitor_scheme_picker: None,
+            ignore_first_mouse: true,
             // --- end weezterm remote features ---
         }
     }
@@ -284,12 +313,11 @@ impl OverlayState {
 
                 let proposed_value = proposed_val.map(|v| data::value_to_display_string(v));
 
-                let status = if proposed_val.is_some() && self.lua_set_fields.contains(f.name) {
-                    // The overlay wrote this value — Lua sees it because
-                    // the overlay config file was loaded.  Still editable.
+                let status = if proposed_val.is_some() && self.overlay_keys.contains(f.name) {
+                    // The overlay previously saved this value — still editable.
                     FieldStatus::OverlayModified
                 } else if proposed_val.is_some() {
-                    // User has proposed a change via the overlay
+                    // User has proposed a new change via the overlay this session
                     FieldStatus::Editable
                 } else if self.lua_set_fields.contains(f.name) {
                     // Lua explicitly set this field (user's hand-written config)
@@ -308,6 +336,8 @@ impl OverlayState {
                     kind: f.kind.clone(),
                     domain_header: None,
                     domain_child: None,
+                    monitor_header: None,
+                    monitor_child: None,
                 }
             })
             .collect();
@@ -349,6 +379,8 @@ impl OverlayState {
                         expanded: entry.expanded,
                     }),
                     domain_child: None,
+                    monitor_header: None,
+                    monitor_child: None,
                 });
 
                 // If expanded, show child fields
@@ -369,6 +401,8 @@ impl OverlayState {
                             kind: field_kind.clone(),
                             domain_header: None,
                             domain_child: Some(idx),
+                            monitor_header: None,
+                            monitor_child: None,
                         });
                     }
 
@@ -383,6 +417,8 @@ impl OverlayState {
                             kind: FieldKind::Text,
                             domain_header: None,
                             domain_child: Some(idx),
+                            monitor_header: None,
+                            monitor_child: None,
                         });
                     }
                 }
@@ -399,12 +435,14 @@ impl OverlayState {
                     kind: FieldKind::Text,
                     domain_header: None,
                     domain_child: None,
+                    monitor_header: None,
+                    monitor_child: None,
                 });
             }
         }
 
         // --- weezterm remote features ---
-        // For Monitors section, show monitor override entries
+        // For Monitors section, show grouped monitor override entries
         if section == Section::Monitors {
             for (idx, entry) in self.monitor_entries.iter().enumerate() {
                 if !filter_lower.is_empty()
@@ -413,28 +451,55 @@ impl OverlayState {
                     continue;
                 }
 
-                let scheme_display = entry
+                let scheme_summary = entry
                     .color_scheme
                     .as_deref()
                     .unwrap_or("(default)")
                     .to_string();
 
-                let display_name = if entry.is_current {
-                    format!("▸ {}", entry.monitor_name)
-                } else {
-                    entry.monitor_name.clone()
-                };
-
+                // Monitor group header row
                 rows.push(SettingRow {
-                    field_name: format!("__monitor_{}__", idx),
-                    display_name,
-                    current_value: scheme_display,
+                    field_name: format!("__monitor_header_{}__", idx),
+                    display_name: entry.monitor_name.clone(),
+                    current_value: scheme_summary,
                     proposed_value: None,
-                    status: FieldStatus::Editable,
-                    kind: FieldKind::ColorScheme,
+                    status: if entry.color_scheme.is_some() {
+                        FieldStatus::Editable
+                    } else {
+                        FieldStatus::Inherited
+                    },
+                    kind: FieldKind::Text,
                     domain_header: None,
                     domain_child: None,
+                    monitor_header: Some(MonitorHeaderInfo {
+                        monitor_index: idx,
+                        is_current: entry.is_current,
+                        expanded: entry.expanded,
+                    }),
+                    monitor_child: None,
                 });
+
+                // If expanded, show child fields
+                if entry.expanded {
+                    let scheme_display = entry
+                        .color_scheme
+                        .as_deref()
+                        .unwrap_or("(default)")
+                        .to_string();
+
+                    rows.push(SettingRow {
+                        field_name: format!("__monitor_{}_color_scheme__", idx),
+                        display_name: "  Color Scheme".to_string(),
+                        current_value: scheme_display,
+                        proposed_value: None,
+                        status: FieldStatus::Editable,
+                        kind: FieldKind::ColorScheme,
+                        domain_header: None,
+                        domain_child: None,
+                        monitor_header: None,
+                        monitor_child: Some(idx),
+                    });
+                }
             }
 
             if self.monitor_entries.is_empty() && filter_lower.is_empty() {
@@ -447,6 +512,8 @@ impl OverlayState {
                     kind: FieldKind::Text,
                     domain_header: None,
                     domain_child: None,
+                    monitor_header: None,
+                    monitor_child: None,
                 });
             }
         }
@@ -518,20 +585,22 @@ impl OverlayState {
     /// Apply an edit: toggle bool, cycle enum, or accept inline text.
     fn apply_edit_for_field(&mut self, field_name: &str, new_value: Value) {
         // --- weezterm remote features ---
-        // Intercept monitor override field names
-        if let Some(idx_str) = field_name
-            .strip_prefix("__monitor_")
-            .and_then(|s| s.strip_suffix("__"))
-        {
-            if let Ok(idx) = idx_str.parse::<usize>() {
-                if idx < self.monitor_entries.len() {
-                    let scheme = match &new_value {
-                        Value::String(s) => Some(s.clone()),
-                        _ => None,
-                    };
-                    self.monitor_entries[idx].color_scheme = scheme;
-                    self.monitors_dirty = true;
-                    self.dirty = true;
+        // Intercept monitor override child field names (__monitor_N_color_scheme__)
+        if let Some(rest) = field_name.strip_prefix("__monitor_") {
+            if let Some(rest) = rest.strip_suffix("__") {
+                if let Some(sep) = rest.find('_') {
+                    let idx_str = &rest[..sep];
+                    if let Ok(idx) = idx_str.parse::<usize>() {
+                        if idx < self.monitor_entries.len() {
+                            let scheme = match &new_value {
+                                Value::String(s) => Some(s.clone()),
+                                _ => None,
+                            };
+                            self.monitor_entries[idx].color_scheme = scheme;
+                            self.monitors_dirty = true;
+                            self.dirty = true;
+                        }
+                    }
                 }
             }
             return;
@@ -717,6 +786,50 @@ impl OverlayState {
             .map(|e| e.config.clone())
             .collect()
     }
+
+    // --- weezterm remote features ---
+    /// Handle Enter on a monitor-related row.
+    fn handle_monitor_enter(&mut self, row: &SettingRow) {
+        // Monitor header: toggle expand/collapse
+        if let Some(ref header) = row.monitor_header {
+            self.monitor_entries[header.monitor_index].expanded =
+                !self.monitor_entries[header.monitor_index].expanded;
+            return;
+        }
+
+        // Monitor child field: open color scheme picker
+        if let Some(monitor_idx) = row.monitor_child {
+            if monitor_idx < self.monitor_entries.len() {
+                self.open_monitor_scheme_picker(monitor_idx);
+            }
+        }
+    }
+
+    /// Open a color scheme picker for a monitor override.
+    fn open_monitor_scheme_picker(&mut self, monitor_idx: usize) {
+        let schemes = data::get_color_schemes();
+        let current = self
+            .monitor_entries
+            .get(monitor_idx)
+            .and_then(|e| e.color_scheme.clone())
+            .unwrap_or_default();
+
+        let filtered: Vec<usize> = (0..schemes.len()).collect();
+        let selected = schemes
+            .iter()
+            .position(|(name, _)| name == &current)
+            .unwrap_or(0);
+
+        self.monitor_scheme_picker = Some(ColorSchemePicker {
+            schemes,
+            filtered,
+            selected,
+            filter: String::new(),
+            scroll_offset: 0,
+        });
+        self.selected_monitor = monitor_idx;
+    }
+    // --- end weezterm remote features ---
 }
 
 /// Extract the field key from a domain child field name like `__domain_2_remote_address__`.
@@ -788,6 +901,19 @@ pub fn run_config_overlay(
 
         match input {
             Ok(Some(input)) => {
+                // --- weezterm remote features ---
+                // Suppress the first mouse click to avoid passthrough from
+                // the overlay that opened us (e.g. command palette click).
+                if state.ignore_first_mouse {
+                    if matches!(input, InputEvent::Mouse(_)) {
+                        state.ignore_first_mouse = false;
+                        continue;
+                    }
+                    // Any key press also clears the flag
+                    state.ignore_first_mouse = false;
+                }
+                // --- end weezterm remote features ---
+
                 // If in inline edit mode, handle separately
                 if let Some(ref mut edit) = state.inline_edit {
                     match input {
@@ -1056,6 +1182,118 @@ pub fn run_config_overlay(
                     continue;
                 }
 
+                // --- weezterm remote features ---
+                // If in monitor color scheme picker mode, handle picker input
+                if let Some(ref mut picker) = state.monitor_scheme_picker {
+                    match input {
+                        InputEvent::Key(KeyEvent {
+                            key: KeyCode::Escape,
+                            ..
+                        }) => {
+                            state.monitor_scheme_picker = None;
+                        }
+                        InputEvent::Key(KeyEvent {
+                            key: KeyCode::Enter,
+                            ..
+                        }) => {
+                            if let Some(&idx) = picker.filtered.get(picker.selected) {
+                                let name = picker.schemes[idx].0.clone();
+                                let monitor_idx = state.selected_monitor;
+                                state.monitor_scheme_picker = None;
+                                let field =
+                                    format!("__monitor_{}_color_scheme__", monitor_idx);
+                                state.apply_edit_for_field(&field, Value::String(name));
+                            }
+                        }
+                        InputEvent::Key(KeyEvent {
+                            key: KeyCode::UpArrow,
+                            ..
+                        }) => {
+                            if picker.selected > 0 {
+                                picker.selected -= 1;
+                            }
+                        }
+                        InputEvent::Key(KeyEvent {
+                            key: KeyCode::DownArrow,
+                            ..
+                        }) => {
+                            if picker.selected + 1 < picker.filtered.len() {
+                                picker.selected += 1;
+                            }
+                        }
+                        InputEvent::Key(KeyEvent {
+                            key: KeyCode::Backspace,
+                            ..
+                        }) => {
+                            picker.filter.pop();
+                            picker.refilter();
+                        }
+                        InputEvent::Key(KeyEvent {
+                            key: KeyCode::Char(c),
+                            ..
+                        }) => {
+                            picker.filter.push(c);
+                            picker.refilter();
+                        }
+                        InputEvent::Mouse(MouseEvent {
+                            y, mouse_buttons, ..
+                        }) => {
+                            if mouse_buttons.contains(MouseButtons::VERT_WHEEL) {
+                                if mouse_buttons.contains(MouseButtons::WHEEL_POSITIVE) {
+                                    picker.selected =
+                                        picker.selected.saturating_sub(3);
+                                } else {
+                                    picker.selected = (picker.selected + 3)
+                                        .min(picker.filtered.len().saturating_sub(1));
+                                }
+                            } else if mouse_buttons == MouseButtons::LEFT {
+                                // Click to select/confirm scheme
+                                let size = ratatui_term.backend().size().unwrap_or_default();
+                                let (area, _, _) =
+                                    render::overlay_rect_pub(size.width, size.height);
+                                let popup_h = area.height.saturating_sub(4).min(30).max(10);
+                                let popup_y =
+                                    area.y + (area.height.saturating_sub(popup_h)) / 2;
+                                let list_start_y = popup_y + 3;
+                                if y >= list_start_y {
+                                    let row_in_list = (y - list_start_y) as usize / 2;
+                                    let visible_items =
+                                        (popup_h.saturating_sub(4)) as usize / 2;
+                                    let scroll = if picker.selected >= visible_items {
+                                        picker.selected.saturating_sub(visible_items - 1)
+                                    } else {
+                                        0
+                                    };
+                                    let clicked_idx = scroll + row_in_list;
+                                    if clicked_idx < picker.filtered.len() {
+                                        if clicked_idx == picker.selected {
+                                            // Double-click: confirm
+                                            let scheme_idx = picker.filtered[clicked_idx];
+                                            let name =
+                                                picker.schemes[scheme_idx].0.clone();
+                                            let monitor_idx = state.selected_monitor;
+                                            state.monitor_scheme_picker = None;
+                                            let field = format!(
+                                                "__monitor_{}_color_scheme__",
+                                                monitor_idx
+                                            );
+                                            state.apply_edit_for_field(
+                                                &field,
+                                                Value::String(name),
+                                            );
+                                        } else {
+                                            picker.selected = clicked_idx;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    continue;
+                }
+                // --- end weezterm remote features ---
+
                 // If in filter mode, handle filter input
                 if state.filter_active {
                     match input {
@@ -1188,6 +1426,13 @@ pub fn run_config_overlay(
                                     || row.field_name.starts_with(DELETE_DOMAIN_FIELD_NAME)
                                 {
                                     state.handle_domain_enter(&row);
+                                // --- weezterm remote features ---
+                                // Monitor-related rows
+                                } else if row.monitor_header.is_some()
+                                    || row.monitor_child.is_some()
+                                {
+                                    state.handle_monitor_enter(&row);
+                                // --- end weezterm remote features ---
                                 } else if !OverlayState::is_row_editable(&row) {
                                     // FixedByLua: don't allow edits
                                 } else {
@@ -1258,6 +1503,12 @@ pub fn run_config_overlay(
                                     }
                                 } else if row.domain_header.is_some() {
                                     state.handle_domain_enter(&row);
+                                // --- weezterm remote features ---
+                                } else if row.monitor_header.is_some()
+                                    || row.monitor_child.is_some()
+                                {
+                                    state.handle_monitor_enter(&row);
+                                // --- end weezterm remote features ---
                                 } else if OverlayState::is_row_editable(&row) {
                                     match &row.kind {
                                         FieldKind::Bool => {
@@ -1399,6 +1650,7 @@ pub fn run_config_overlay(
                                             && state.active_panel == Panel::Settings;
                                         state.selected_setting = idx;
                                         state.active_panel = Panel::Settings;
+
                                         if was_selected {
                                             if let Some(sr) = state.selected_row() {
                                                 // Domain rows
@@ -1410,6 +1662,12 @@ pub fn run_config_overlay(
                                                         .starts_with(DELETE_DOMAIN_FIELD_NAME)
                                                 {
                                                     state.handle_domain_enter(&sr);
+                                                // --- weezterm remote features ---
+                                                } else if sr.monitor_header.is_some()
+                                                    || sr.monitor_child.is_some()
+                                                {
+                                                    state.handle_monitor_enter(&sr);
+                                                // --- end weezterm remote features ---
                                                 } else if OverlayState::is_row_editable(&sr) {
                                                     match &sr.kind {
                                                         FieldKind::Bool => {
@@ -1555,6 +1813,8 @@ mod test {
                 expanded: false,
             }),
             domain_child: None,
+            monitor_header: None,
+            monitor_child: None,
         };
         assert!(row.domain_header.is_some());
         assert!(row.domain_child.is_none());

--- a/wezterm-gui/src/overlay/config_overlay/mod.rs
+++ b/wezterm-gui/src/overlay/config_overlay/mod.rs
@@ -223,8 +223,7 @@ impl OverlayState {
 
         // Track which keys came from the saved overlay JSON so we can
         // distinguish them from keys genuinely set by the user's Lua config.
-        let overlay_keys: std::collections::HashSet<String> =
-            proposals.keys().cloned().collect();
+        let overlay_keys: std::collections::HashSet<String> = proposals.keys().cloned().collect();
 
         // Build domain entries: Lua-sourced (read-only) + overlay-sourced (editable)
         let mut domain_entries = data::domains_from_config();
@@ -1200,8 +1199,7 @@ pub fn run_config_overlay(
                                 let name = picker.schemes[idx].0.clone();
                                 let monitor_idx = state.selected_monitor;
                                 state.monitor_scheme_picker = None;
-                                let field =
-                                    format!("__monitor_{}_color_scheme__", monitor_idx);
+                                let field = format!("__monitor_{}_color_scheme__", monitor_idx);
                                 state.apply_edit_for_field(&field, Value::String(name));
                             }
                         }
@@ -1240,8 +1238,7 @@ pub fn run_config_overlay(
                         }) => {
                             if mouse_buttons.contains(MouseButtons::VERT_WHEEL) {
                                 if mouse_buttons.contains(MouseButtons::WHEEL_POSITIVE) {
-                                    picker.selected =
-                                        picker.selected.saturating_sub(3);
+                                    picker.selected = picker.selected.saturating_sub(3);
                                 } else {
                                     picker.selected = (picker.selected + 3)
                                         .min(picker.filtered.len().saturating_sub(1));
@@ -1252,13 +1249,11 @@ pub fn run_config_overlay(
                                 let (area, _, _) =
                                     render::overlay_rect_pub(size.width, size.height);
                                 let popup_h = area.height.saturating_sub(4).min(30).max(10);
-                                let popup_y =
-                                    area.y + (area.height.saturating_sub(popup_h)) / 2;
+                                let popup_y = area.y + (area.height.saturating_sub(popup_h)) / 2;
                                 let list_start_y = popup_y + 3;
                                 if y >= list_start_y {
                                     let row_in_list = (y - list_start_y) as usize / 2;
-                                    let visible_items =
-                                        (popup_h.saturating_sub(4)) as usize / 2;
+                                    let visible_items = (popup_h.saturating_sub(4)) as usize / 2;
                                     let scroll = if picker.selected >= visible_items {
                                         picker.selected.saturating_sub(visible_items - 1)
                                     } else {
@@ -1269,18 +1264,12 @@ pub fn run_config_overlay(
                                         if clicked_idx == picker.selected {
                                             // Double-click: confirm
                                             let scheme_idx = picker.filtered[clicked_idx];
-                                            let name =
-                                                picker.schemes[scheme_idx].0.clone();
+                                            let name = picker.schemes[scheme_idx].0.clone();
                                             let monitor_idx = state.selected_monitor;
                                             state.monitor_scheme_picker = None;
-                                            let field = format!(
-                                                "__monitor_{}_color_scheme__",
-                                                monitor_idx
-                                            );
-                                            state.apply_edit_for_field(
-                                                &field,
-                                                Value::String(name),
-                                            );
+                                            let field =
+                                                format!("__monitor_{}_color_scheme__", monitor_idx);
+                                            state.apply_edit_for_field(&field, Value::String(name));
                                         } else {
                                             picker.selected = clicked_idx;
                                         }

--- a/wezterm-gui/src/overlay/config_overlay/persistence.rs
+++ b/wezterm-gui/src/overlay/config_overlay/persistence.rs
@@ -6,15 +6,21 @@
 //! --- weezterm remote features ---
 
 use super::data::SshDomainConfig;
+// --- weezterm remote features ---
+use super::data::MonitorOverrideEntry;
+// --- end weezterm remote features ---
 use std::collections::HashMap;
 use wezterm_dynamic::Value;
 
 const OVERLAY_FILE_NAME: &str = "config-overlay.json";
 
-/// Combined overlay data: proposals + user-managed SSH domains.
+/// Combined overlay data: proposals + user-managed SSH domains + monitor overrides.
 pub struct OverlayData {
     pub proposals: HashMap<String, Value>,
     pub ssh_domains: Vec<SshDomainConfig>,
+    // --- weezterm remote features ---
+    pub monitor_overrides: Vec<MonitorOverrideEntry>,
+    // --- end weezterm remote features ---
 }
 
 impl Default for OverlayData {
@@ -22,6 +28,9 @@ impl Default for OverlayData {
         Self {
             proposals: HashMap::new(),
             ssh_domains: vec![],
+            // --- weezterm remote features ---
+            monitor_overrides: vec![],
+            // --- end weezterm remote features ---
         }
     }
 }
@@ -40,19 +49,11 @@ fn overlay_file_path() -> Option<std::path::PathBuf> {
 pub fn load_overlay_data() -> anyhow::Result<OverlayData> {
     let path = match overlay_file_path() {
         Some(p) => p,
-        None => {
-            return Ok(OverlayData {
-                proposals: HashMap::new(),
-                ssh_domains: vec![],
-            })
-        }
+        None => return Ok(OverlayData::default()),
     };
 
     if !path.exists() {
-        return Ok(OverlayData {
-            proposals: HashMap::new(),
-            ssh_domains: vec![],
-        });
+        return Ok(OverlayData::default());
     }
 
     let content = std::fs::read_to_string(&path)?;
@@ -60,7 +61,7 @@ pub fn load_overlay_data() -> anyhow::Result<OverlayData> {
 
     match &json {
         serde_json::Value::Object(obj) if obj.contains_key("proposals") => {
-            // New format: { "proposals": {...}, "ssh_domains": [...] }
+            // New format: { "proposals": {...}, "ssh_domains": [...], "monitor_overrides": [...] }
             let proposals = if let Some(p) = obj.get("proposals") {
                 parse_proposals(p)
             } else {
@@ -71,9 +72,19 @@ pub fn load_overlay_data() -> anyhow::Result<OverlayData> {
             } else {
                 vec![]
             };
+            // --- weezterm remote features ---
+            let monitor_overrides = if let Some(m) = obj.get("monitor_overrides") {
+                parse_monitor_overrides(m)
+            } else {
+                vec![]
+            };
+            // --- end weezterm remote features ---
             Ok(OverlayData {
                 proposals,
                 ssh_domains,
+                // --- weezterm remote features ---
+                monitor_overrides,
+                // --- end weezterm remote features ---
             })
         }
         serde_json::Value::Object(_) => {
@@ -81,11 +92,13 @@ pub fn load_overlay_data() -> anyhow::Result<OverlayData> {
             Ok(OverlayData {
                 proposals: parse_proposals(&json),
                 ssh_domains: vec![],
+                monitor_overrides: vec![],
             })
         }
         _ => Ok(OverlayData {
             proposals: HashMap::new(),
             ssh_domains: vec![],
+            monitor_overrides: vec![],
         }),
     }
 }
@@ -95,10 +108,11 @@ pub fn load_proposals() -> anyhow::Result<HashMap<String, Value>> {
     Ok(load_overlay_data()?.proposals)
 }
 
-/// Save overlay data (proposals + domains) to disk as JSON.
+/// Save overlay data (proposals + domains + monitor overrides) to disk as JSON.
 pub fn save_overlay_data(
     proposals: &HashMap<String, Value>,
     ssh_domains: &[SshDomainConfig],
+    monitor_overrides: &[MonitorOverrideEntry],
 ) -> anyhow::Result<()> {
     let path = match overlay_file_path() {
         Some(p) => p,
@@ -128,6 +142,19 @@ pub fn save_overlay_data(
         serde_json::Value::Array(domains_arr),
     );
 
+    // --- weezterm remote features ---
+    // Serialize monitor overrides (only those with at least one override set)
+    let monitors_arr: Vec<serde_json::Value> = monitor_overrides
+        .iter()
+        .filter(|e| e.color_scheme.is_some())
+        .map(monitor_override_to_json)
+        .collect();
+    root.insert(
+        "monitor_overrides".to_string(),
+        serde_json::Value::Array(monitors_arr),
+    );
+    // --- end weezterm remote features ---
+
     let json_str = serde_json::to_string_pretty(&serde_json::Value::Object(root))?;
     std::fs::write(&path, json_str)?;
 
@@ -137,12 +164,17 @@ pub fn save_overlay_data(
 
 /// Save proposals to disk as JSON (backward-compatible wrapper).
 pub fn save_proposals(proposals: &HashMap<String, Value>) -> anyhow::Result<()> {
-    // Load existing data to preserve domains
+    // Load existing data to preserve domains and monitor overrides
     let existing = load_overlay_data().unwrap_or(OverlayData {
         proposals: HashMap::new(),
         ssh_domains: vec![],
+        monitor_overrides: vec![],
     });
-    save_overlay_data(proposals, &existing.ssh_domains)
+    save_overlay_data(
+        proposals,
+        &existing.ssh_domains,
+        &existing.monitor_overrides,
+    )
 }
 
 /// Convert proposals map into a `wezterm_dynamic::Value::Object` suitable
@@ -244,6 +276,51 @@ fn domain_to_json(dom: &SshDomainConfig) -> serde_json::Value {
     );
     serde_json::Value::Object(obj)
 }
+
+// --- weezterm remote features ---
+fn parse_monitor_overrides(val: &serde_json::Value) -> Vec<MonitorOverrideEntry> {
+    let mut entries = vec![];
+    if let serde_json::Value::Array(arr) = val {
+        for item in arr {
+            if let serde_json::Value::Object(obj) = item {
+                let monitor_name = obj
+                    .get("monitor")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let color_scheme = obj
+                    .get("color_scheme")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                if !monitor_name.is_empty() {
+                    entries.push(MonitorOverrideEntry {
+                        monitor_name,
+                        color_scheme,
+                        is_current: false,
+                    });
+                }
+            }
+        }
+    }
+    entries
+}
+
+fn monitor_override_to_json(entry: &MonitorOverrideEntry) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "monitor".to_string(),
+        serde_json::Value::String(entry.monitor_name.clone()),
+    );
+    if let Some(ref scheme) = entry.color_scheme {
+        obj.insert(
+            "color_scheme".to_string(),
+            serde_json::Value::String(scheme.clone()),
+        );
+    }
+    serde_json::Value::Object(obj)
+}
+// --- end weezterm remote features ---
 
 /// Convert a `serde_json::Value` to `wezterm_dynamic::Value`.
 fn json_to_dynamic(val: &serde_json::Value) -> Value {

--- a/wezterm-gui/src/overlay/config_overlay/persistence.rs
+++ b/wezterm-gui/src/overlay/config_overlay/persistence.rs
@@ -298,6 +298,8 @@ fn parse_monitor_overrides(val: &serde_json::Value) -> Vec<MonitorOverrideEntry>
                         monitor_name,
                         color_scheme,
                         is_current: false,
+                        expanded: false,
+                        screen_rect: None,
                     });
                 }
             }

--- a/wezterm-gui/src/overlay/config_overlay/render.rs
+++ b/wezterm-gui/src/overlay/config_overlay/render.rs
@@ -92,9 +92,15 @@ pub fn ui(frame: &mut Frame, state: &mut OverlayState, theme: &Theme) -> LayoutG
     let right_area = horiz[1];
 
     // Right area: split into settings + details
+    // Use more detail rows for the Monitors section to show the layout diagram
+    let detail_rows = if state.current_section() == super::data::Section::Monitors {
+        8
+    } else {
+        DETAIL_ROWS
+    };
     let right_vert = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(DETAIL_ROWS)])
+        .constraints([Constraint::Min(3), Constraint::Length(detail_rows)])
         .split(right_area);
 
     let settings_area = right_vert[0];
@@ -126,6 +132,13 @@ pub fn ui(frame: &mut Frame, state: &mut OverlayState, theme: &Theme) -> LayoutG
     if state.scheme_picker.is_some() {
         render_scheme_picker(frame, state, theme, area);
     }
+
+    // --- weezterm remote features ---
+    // ── Monitor color scheme picker popup ─────────────────────────────
+    if state.monitor_scheme_picker.is_some() {
+        render_monitor_scheme_picker(frame, state, theme, area);
+    }
+    // --- end weezterm remote features ---
 
     LayoutGeo {
         left_pad,
@@ -246,6 +259,47 @@ fn render_settings(frame: &mut Frame, state: &mut OverlayState, theme: &Theme, a
                     ratatui::text::Text::styled(badge.to_string(), bdg_style),
                 ]);
             }
+
+            // --- weezterm remote features ---
+            // Monitor group header row
+            if let Some(ref header) = setting.monitor_header {
+                let arrow = if header.expanded {
+                    "\u{25be}"
+                } else {
+                    "\u{25b8}"
+                };
+                let current_marker = if header.is_current { " \u{25c6}" } else { "" };
+                let label = format!(" {} {}{} ", arrow, setting.display_name, current_marker);
+                let badge = if setting.status == FieldStatus::Inherited {
+                    "inherited"
+                } else {
+                    "modified"
+                };
+                let (name_style, val_style, bdg_style) = if is_selected {
+                    (theme.selected, theme.selected_value, theme.selected_badge)
+                } else {
+                    (
+                        theme.text.add_modifier(Modifier::BOLD),
+                        theme.value,
+                        if setting.status == FieldStatus::Inherited {
+                            theme.badge_inherited
+                        } else {
+                            theme.badge_editable
+                        },
+                    )
+                };
+                let sep_line = "\u{2500}".repeat(name_w.saturating_sub(label.len()).max(1));
+                let name_cell = Line::from(vec![
+                    Span::styled(label, name_style),
+                    Span::styled(sep_line, theme.border),
+                ]);
+                return Row::new(vec![
+                    ratatui::text::Text::from(name_cell),
+                    ratatui::text::Text::styled(setting.current_value.clone(), val_style),
+                    ratatui::text::Text::styled(badge.to_string(), bdg_style),
+                ]);
+            }
+            // --- end weezterm remote features ---
 
             // "Add SSH Domain..." action row
             if setting.field_name == super::ADD_DOMAIN_FIELD_NAME {
@@ -399,6 +453,21 @@ fn render_details(frame: &mut Frame, state: &OverlayState, theme: &Theme, area: 
                         theme.detail,
                     )),
                 ]
+            // --- weezterm remote features ---
+            } else if row.monitor_header.is_some() || row.monitor_child.is_some() {
+                let selected_idx = row
+                    .monitor_header
+                    .as_ref()
+                    .map(|h| h.monitor_index)
+                    .or(row.monitor_child);
+                render_monitor_layout_diagram(
+                    &state.monitor_entries,
+                    selected_idx,
+                    area.width.saturating_sub(2) as usize,
+                    area.height.saturating_sub(1) as usize,
+                    theme,
+                )
+            // --- end weezterm remote features ---
             } else {
                 let field_def = state.field_defs.iter().find(|f| f.name == row.field_name);
                 let kind_label = field_def
@@ -464,6 +533,215 @@ fn render_details(frame: &mut Frame, state: &OverlayState, theme: &Theme, area: 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }
+
+// --- weezterm remote features ---
+// ─── Monitor layout diagram ────────────────────────────────────────────────
+
+/// Render an ASCII layout diagram of monitor positions with numbered boxes.
+/// Uses a connection-based approach so shared edges produce proper junctions
+/// (┬ ┴ ├ ┤ ┼) instead of overwriting each other.
+fn render_monitor_layout_diagram(
+    monitors: &[super::data::MonitorOverrideEntry],
+    selected_idx: Option<usize>,
+    avail_w: usize,
+    avail_h: usize,
+    theme: &super::theme::Theme,
+) -> Vec<Line<'static>> {
+    use super::data::MonitorRect;
+
+    let rects: Vec<(usize, MonitorRect)> = monitors
+        .iter()
+        .enumerate()
+        .filter_map(|(i, m)| m.screen_rect.map(|r| (i, r)))
+        .collect();
+
+    if rects.is_empty() {
+        return vec![Line::from(Span::styled(
+            " (no monitor geometry available)",
+            theme.text_dim,
+        ))];
+    }
+
+    // Bounding box
+    let min_x = rects.iter().map(|(_, r)| r.x).min().unwrap();
+    let min_y = rects.iter().map(|(_, r)| r.y).min().unwrap();
+    let max_x = rects.iter().map(|(_, r)| r.x + r.width).max().unwrap();
+    let max_y = rects.iter().map(|(_, r)| r.y + r.height).max().unwrap();
+
+    let total_w = (max_x - min_x) as f64;
+    let total_h = (max_y - min_y) as f64;
+    if total_w <= 0.0 || total_h <= 0.0 {
+        return vec![Line::from(Span::styled(
+            " (invalid monitor geometry)",
+            theme.text_dim,
+        ))];
+    }
+
+    let draw_w = avail_w.saturating_sub(1).max(10);
+    let draw_h = avail_h.max(3);
+
+    // Scale to fit, preserving aspect ratio (terminal chars ~2:1)
+    let char_aspect = 2.0_f64;
+    let scale_x = draw_w as f64 / total_w;
+    let scale_y = draw_h as f64 / (total_h / char_aspect);
+    let scale = scale_x.min(scale_y);
+
+    let grid_w = (total_w * scale).ceil() as usize + 1;
+    let grid_h = (total_h / char_aspect * scale).ceil() as usize + 1;
+    let grid_w = grid_w.min(draw_w).max(1);
+    let grid_h = grid_h.min(draw_h).max(1);
+
+    // Connection grid: at each point, which directions have border lines?
+    // Packed as bits: 1=up, 2=down, 4=left, 8=right
+    let mut conn: Vec<Vec<u8>> = vec![vec![0u8; grid_w]; grid_h];
+    // Owner grid: which monitor index owns each cell (for styling)
+    let mut owner: Vec<Vec<Option<usize>>> = vec![vec![None; grid_w]; grid_h];
+    // Character overlay: for labels placed on top of interior cells
+    let mut label_grid: Vec<Vec<Option<char>>> = vec![vec![None; grid_w]; grid_h];
+
+    // Convert each monitor rect to grid coordinates and draw
+    for &(idx, ref rect) in &rects {
+        let x1 = ((rect.x - min_x) as f64 * scale).round() as usize;
+        let y1 = ((rect.y - min_y) as f64 / char_aspect * scale).round() as usize;
+        let x2 = (((rect.x + rect.width - min_x) as f64) * scale).round() as usize;
+        let y2 =
+            (((rect.y + rect.height - min_y) as f64) / char_aspect * scale).round() as usize;
+
+        let x1 = x1.min(grid_w.saturating_sub(1));
+        let x2 = x2.min(grid_w.saturating_sub(1)).max(x1 + 2);
+        let y1 = y1.min(grid_h.saturating_sub(1));
+        let y2 = y2.min(grid_h.saturating_sub(1)).max(y1 + 2);
+
+        // Top border: horizontal connections
+        for x in x1..x2 {
+            if y1 < grid_h && x + 1 < grid_w {
+                conn[y1][x] |= 8; // right
+                conn[y1][x + 1] |= 4; // left
+            }
+        }
+        // Bottom border
+        for x in x1..x2 {
+            if y2 < grid_h && x + 1 < grid_w {
+                conn[y2][x] |= 8;
+                conn[y2][x + 1] |= 4;
+            }
+        }
+        // Left border: vertical connections
+        for y in y1..y2 {
+            if x1 < grid_w && y + 1 < grid_h {
+                conn[y][x1] |= 2; // down
+                conn[y + 1][x1] |= 1; // up
+            }
+        }
+        // Right border
+        for y in y1..y2 {
+            if x2 < grid_w && y + 1 < grid_h {
+                conn[y][x2] |= 2;
+                conn[y + 1][x2] |= 1;
+            }
+        }
+
+        // Fill interior ownership
+        for y in y1..=y2.min(grid_h.saturating_sub(1)) {
+            for x in x1..=x2.min(grid_w.saturating_sub(1)) {
+                owner[y][x] = Some(idx);
+            }
+        }
+
+        // Place label in center
+        let center_y = (y1 + y2) / 2;
+        let center_x = (x1 + x2) / 2;
+        let is_current = monitors.get(idx).map_or(false, |m| m.is_current);
+        let label = if is_current {
+            format!("\u{25c6}{}", idx + 1)
+        } else {
+            format!("{}", idx + 1)
+        };
+        let label_start = center_x.saturating_sub(label.len() / 2);
+        for (ci, ch) in label.chars().enumerate() {
+            let px = label_start + ci;
+            if center_y > y1 && center_y < y2 && px > x1 && px < x2 && px < grid_w {
+                label_grid[center_y][px] = Some(ch);
+            }
+        }
+    }
+
+    // Resolve connections to box-drawing characters and build output
+    let resolve = |c: u8| -> char {
+        match (c & 1 != 0, c & 2 != 0, c & 4 != 0, c & 8 != 0) {
+            // (up, down, left, right)
+            (false, true, false, true) => '\u{250c}',  // ┌
+            (false, true, true, false) => '\u{2510}',  // ┐
+            (true, false, false, true) => '\u{2514}',  // └
+            (true, false, true, false) => '\u{2518}',  // ┘
+            (false, false, true, true) => '\u{2500}',  // ─
+            (true, true, false, false) => '\u{2502}',  // │
+            (true, true, false, true) => '\u{251c}',   // ├
+            (true, true, true, false) => '\u{2524}',   // ┤
+            (false, true, true, true) => '\u{252c}',   // ┬
+            (true, false, true, true) => '\u{2534}',   // ┴
+            (true, true, true, true) => '\u{253c}',    // ┼
+            // Partial (dead-end lines)
+            (false, true, false, false) => '\u{2502}', // │
+            (true, false, false, false) => '\u{2502}', // │
+            (false, false, true, false) => '\u{2500}', // ─
+            (false, false, false, true) => '\u{2500}', // ─
+            _ => ' ',
+        }
+    };
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for y in 0..grid_h {
+        let mut spans: Vec<Span<'static>> = vec![Span::raw(" ")];
+        let mut current_text = String::new();
+        let mut current_owner: Option<usize> = None;
+        let mut current_is_border = false;
+
+        for x in 0..grid_w {
+            let c = conn[y][x];
+            let own = owner[y][x];
+            let lbl = label_grid[y][x];
+            let is_border = c != 0;
+
+            let ch = if let Some(label_ch) = lbl {
+                label_ch
+            } else if c != 0 {
+                resolve(c)
+            } else {
+                ' '
+            };
+
+            // Flush span when owner or border-ness changes
+            if own != current_owner || is_border != current_is_border {
+                if !current_text.is_empty() {
+                    let style = match current_owner {
+                        Some(i) if Some(i) == selected_idx => theme.selected,
+                        Some(_) if current_is_border => theme.border,
+                        Some(_) => theme.text,
+                        None => theme.text_dim,
+                    };
+                    spans.push(Span::styled(current_text, style));
+                    current_text = String::new();
+                }
+                current_owner = own;
+                current_is_border = is_border;
+            }
+            current_text.push(ch);
+        }
+        if !current_text.is_empty() {
+            let style = match current_owner {
+                Some(i) if Some(i) == selected_idx => theme.selected,
+                Some(_) if current_is_border => theme.border,
+                Some(_) => theme.text,
+                None => theme.text_dim,
+            };
+            spans.push(Span::styled(current_text, style));
+        }
+        lines.push(Line::from(spans));
+    }
+    lines
+}
+// --- end weezterm remote features ---
 
 // ─── Footer ─────────────────────────────────────────────────────────────────
 
@@ -654,11 +932,21 @@ fn render_enum_picker(frame: &mut Frame, state: &OverlayState, theme: &Theme, pa
 
 // ─── Color scheme picker popup ──────────────────────────────────────────────
 
-fn render_scheme_picker(frame: &mut Frame, state: &OverlayState, theme: &Theme, parent: Rect) {
+fn render_scheme_picker(frame: &mut Frame, state: &OverlayState, _theme: &Theme, parent: Rect) {
     let picker = match &state.scheme_picker {
         Some(p) => p,
         None => return,
     };
+    render_scheme_picker_common(frame, picker, _theme, parent, "Color Scheme");
+}
+
+fn render_scheme_picker_common(
+    frame: &mut Frame,
+    picker: &super::ColorSchemePicker,
+    _theme: &Theme,
+    parent: Rect,
+    label: &str,
+) {
 
     let popup_w = parent.width.saturating_sub(4).min(80).max(40);
     let popup_h = parent.height.saturating_sub(4).min(30).max(10);
@@ -689,7 +977,8 @@ fn render_scheme_picker(frame: &mut Frame, state: &OverlayState, theme: &Theme, 
         .unwrap_or(ratatui::style::Color::Black);
 
     let title = format!(
-        " Color Scheme ({}/{}) ",
+        " {} ({}/{}) ",
+        label,
         picker.filtered.len(),
         picker.schemes.len()
     );
@@ -828,3 +1117,25 @@ fn rgba_to_color(color: &config::RgbaColor) -> ratatui::style::Color {
     let (r, g, b, _) = color.to_srgb_u8();
     ratatui::style::Color::Rgb(r, g, b)
 }
+
+// --- weezterm remote features ---
+fn render_monitor_scheme_picker(
+    frame: &mut Frame,
+    state: &OverlayState,
+    theme: &Theme,
+    parent: Rect,
+) {
+    let picker = match &state.monitor_scheme_picker {
+        Some(p) => p,
+        None => return,
+    };
+
+    let monitor_name = state
+        .monitor_entries
+        .get(state.selected_monitor)
+        .map(|e| e.monitor_name.as_str())
+        .unwrap_or("Monitor");
+
+    render_scheme_picker_common(frame, picker, theme, parent, monitor_name);
+}
+// --- end weezterm remote features ---

--- a/wezterm-gui/src/overlay/config_overlay/render.rs
+++ b/wezterm-gui/src/overlay/config_overlay/render.rs
@@ -604,8 +604,7 @@ fn render_monitor_layout_diagram(
         let x1 = ((rect.x - min_x) as f64 * scale).round() as usize;
         let y1 = ((rect.y - min_y) as f64 / char_aspect * scale).round() as usize;
         let x2 = (((rect.x + rect.width - min_x) as f64) * scale).round() as usize;
-        let y2 =
-            (((rect.y + rect.height - min_y) as f64) / char_aspect * scale).round() as usize;
+        let y2 = (((rect.y + rect.height - min_y) as f64) / char_aspect * scale).round() as usize;
 
         let x1 = x1.min(grid_w.saturating_sub(1));
         let x2 = x2.min(grid_w.saturating_sub(1)).max(x1 + 2);
@@ -670,17 +669,17 @@ fn render_monitor_layout_diagram(
     let resolve = |c: u8| -> char {
         match (c & 1 != 0, c & 2 != 0, c & 4 != 0, c & 8 != 0) {
             // (up, down, left, right)
-            (false, true, false, true) => '\u{250c}',  // ┌
-            (false, true, true, false) => '\u{2510}',  // ┐
-            (true, false, false, true) => '\u{2514}',  // └
-            (true, false, true, false) => '\u{2518}',  // ┘
-            (false, false, true, true) => '\u{2500}',  // ─
-            (true, true, false, false) => '\u{2502}',  // │
-            (true, true, false, true) => '\u{251c}',   // ├
-            (true, true, true, false) => '\u{2524}',   // ┤
-            (false, true, true, true) => '\u{252c}',   // ┬
-            (true, false, true, true) => '\u{2534}',   // ┴
-            (true, true, true, true) => '\u{253c}',    // ┼
+            (false, true, false, true) => '\u{250c}', // ┌
+            (false, true, true, false) => '\u{2510}', // ┐
+            (true, false, false, true) => '\u{2514}', // └
+            (true, false, true, false) => '\u{2518}', // ┘
+            (false, false, true, true) => '\u{2500}', // ─
+            (true, true, false, false) => '\u{2502}', // │
+            (true, true, false, true) => '\u{251c}',  // ├
+            (true, true, true, false) => '\u{2524}',  // ┤
+            (false, true, true, true) => '\u{252c}',  // ┬
+            (true, false, true, true) => '\u{2534}',  // ┴
+            (true, true, true, true) => '\u{253c}',   // ┼
             // Partial (dead-end lines)
             (false, true, false, false) => '\u{2502}', // │
             (true, false, false, false) => '\u{2502}', // │
@@ -947,7 +946,6 @@ fn render_scheme_picker_common(
     parent: Rect,
     label: &str,
 ) {
-
     let popup_w = parent.width.saturating_sub(4).min(80).max(40);
     let popup_h = parent.height.saturating_sub(4).min(30).max(10);
     let popup_x = parent.x + (parent.width.saturating_sub(popup_w)) / 2;

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -465,6 +465,15 @@ pub struct TermWindow {
     gl: Option<Rc<glium::backend::Context>>,
     webgpu: Option<Rc<WebGpuState>>,
     config_subscription: Option<config::ConfigSubscription>,
+
+    // --- weezterm remote features ---
+    /// The name of the monitor the window is currently on.
+    current_screen_name: Option<String>,
+    /// Tracks the color_scheme value injected by monitor overrides,
+    /// so we can distinguish it from user-set overrides and restore
+    /// the user's value when leaving the monitor.
+    monitor_injected_color_scheme: Option<String>,
+    // --- end weezterm remote features ---
 }
 
 impl TermWindow {
@@ -687,6 +696,10 @@ impl TermWindow {
             last_frame_duration: Duration::ZERO,
             fps: 0.,
             config_subscription: None,
+            // --- weezterm remote features ---
+            current_screen_name: None,
+            monitor_injected_color_scheme: None,
+            // --- end weezterm remote features ---
             os_parameters: None,
             gl: None,
             webgpu: None,
@@ -1058,6 +1071,11 @@ impl TermWindow {
                 Ok(true)
             }
             WindowEvent::DraggedFile(_) => Ok(true),
+            // --- weezterm remote features ---
+            WindowEvent::ScreenChanged { screen_name } => {
+                self.handle_screen_changed(screen_name);
+                Ok(true)
+            } // --- end weezterm remote features ---
         }
     }
 
@@ -1845,6 +1863,74 @@ impl TermWindow {
         self.emit_window_event("window-config-reloaded", None);
     }
 
+    // --- weezterm remote features ---
+    /// Called when the window moves to a different monitor.
+    /// Looks up `monitor_overrides` for the new screen name and
+    /// applies or removes the color_scheme override accordingly.
+    fn handle_screen_changed(&mut self, screen_name: String) {
+        log::info!("Window moved to monitor: {:?}", screen_name);
+        self.current_screen_name = Some(screen_name.clone());
+        self.apply_monitor_overrides(&screen_name);
+    }
+
+    /// Applies or removes monitor-specific config overrides
+    /// based on the current monitor name.
+    fn apply_monitor_overrides(&mut self, screen_name: &str) {
+        // Find a matching monitor override in the config
+        let matching_scheme = self
+            .config
+            .monitor_overrides
+            .iter()
+            .find(|mo| mo.monitor == screen_name)
+            .and_then(|mo| mo.color_scheme.clone());
+
+        // Check if anything actually changed
+        if matching_scheme == self.monitor_injected_color_scheme {
+            return;
+        }
+
+        let old = self.monitor_injected_color_scheme.take();
+
+        // Build a mutable copy of config_overrides as an Object
+        let mut overrides_obj = match self.config_overrides.clone() {
+            wezterm_dynamic::Value::Object(obj) => obj,
+            _ => Default::default(),
+        };
+
+        let key = wezterm_dynamic::Value::String("color_scheme".to_string());
+
+        match matching_scheme {
+            Some(scheme) => {
+                log::info!(
+                    "Applying monitor override: color_scheme={:?} for monitor {:?}",
+                    scheme,
+                    screen_name
+                );
+                overrides_obj.insert(key, wezterm_dynamic::Value::String(scheme.clone()));
+                self.monitor_injected_color_scheme = Some(scheme);
+            }
+            None => {
+                // No override for this monitor — remove any previously
+                // injected color_scheme, but only if it was set by the
+                // monitor system (not by the user via config overlay / Lua).
+                if old.is_some() {
+                    log::info!(
+                        "Removing monitor override for monitor {:?}, reverting color_scheme",
+                        screen_name
+                    );
+                    overrides_obj.remove(&key);
+                }
+            }
+        }
+
+        let new_overrides = wezterm_dynamic::Value::Object(overrides_obj);
+        if new_overrides != self.config_overrides {
+            self.config_overrides = new_overrides;
+            self.config_was_reloaded();
+        }
+    }
+    // --- end weezterm remote features ---
+
     fn invalidate_modal(&mut self) {
         if let Some(modal) = self.get_modal() {
             modal.reconfigure(self);
@@ -2439,6 +2525,7 @@ impl TermWindow {
     // --- weezterm remote features ---
     fn show_config_overlay(&mut self) {
         use crate::overlay::config_overlay;
+        use crate::overlay::config_overlay::data;
         use wezterm_dynamic::ToDynamic;
 
         let mux = Mux::get();
@@ -2459,6 +2546,18 @@ impl TermWindow {
 
         let window = self.window.clone().unwrap();
         let tab_id = tab.tab_id();
+        // --- weezterm remote features ---
+        let current_screen = self.current_screen_name.clone();
+        let screen_names: Vec<String> = {
+            use ::window::ConnectionOps;
+            ::window::Connection::get()
+                .and_then(|conn| conn.screens().ok())
+                .map(|screens| screens.by_name.keys().cloned().collect())
+                .unwrap_or_default()
+        };
+        let monitor_entries =
+            data::monitors_from_config_with_screens(&screen_names, current_screen.as_deref());
+        // --- end weezterm remote features ---
         let (overlay, future) = start_overlay(self, &tab, move |_tab_id, term| {
             config_overlay::run_config_overlay(
                 term,
@@ -2466,6 +2565,9 @@ impl TermWindow {
                 default_values,
                 overlay_data.proposals,
                 overlay_data.ssh_domains,
+                // --- weezterm remote features ---
+                monitor_entries,
+                // --- end weezterm remote features ---
                 palette,
             )
         });
@@ -2477,16 +2579,23 @@ impl TermWindow {
                 Ok(config_overlay::ConfigOverlayAction::Save {
                     proposals,
                     ssh_domains,
+                    // --- weezterm remote features ---
+                    monitor_overrides,
+                    // --- end weezterm remote features ---
                 }) => {
                     log::info!(
                         "Config overlay: saving {} proposals, {} domains",
                         proposals.len(),
                         ssh_domains.len()
                     );
-                    // Persist proposals + domains to disk
-                    if let Err(e) =
-                        config_overlay::persistence::save_overlay_data(&proposals, &ssh_domains)
-                    {
+                    // Persist proposals + domains + monitor overrides to disk
+                    if let Err(e) = config_overlay::persistence::save_overlay_data(
+                        &proposals,
+                        &ssh_domains,
+                        // --- weezterm remote features ---
+                        &monitor_overrides,
+                        // --- end weezterm remote features ---
+                    ) {
                         log::error!("Failed to save config overlay data: {:#}", e);
                     }
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -916,9 +916,8 @@ impl TermWindow {
                         .iter()
                         .any(|m| m.color_scheme.is_some())
                 {
-                    let mut overrides = config_overlay::persistence::proposals_to_overrides(
-                        overlay_data.proposals,
-                    );
+                    let mut overrides =
+                        config_overlay::persistence::proposals_to_overrides(overlay_data.proposals);
                     let config_monitor_overrides =
                         config_overlay::data::to_config_monitor_overrides(
                             &overlay_data.monitor_overrides,
@@ -927,9 +926,7 @@ impl TermWindow {
                         if let wezterm_dynamic::Value::Object(ref mut obj) = overrides {
                             use wezterm_dynamic::ToDynamic;
                             obj.insert(
-                                wezterm_dynamic::Value::String(
-                                    "monitor_overrides".to_string(),
-                                ),
+                                wezterm_dynamic::Value::String("monitor_overrides".to_string()),
                                 config_monitor_overrides.to_dynamic(),
                             );
                         }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -902,6 +902,50 @@ impl TermWindow {
             myself.subscribe_to_pane_updates();
             myself.emit_window_event("window-config-reloaded", None);
             myself.emit_status_event();
+
+            // --- weezterm remote features ---
+            // Apply saved overlay proposals + monitor overrides at startup
+            // so config overlay settings persist across restarts.
+            {
+                use crate::overlay::config_overlay;
+                let overlay_data =
+                    config_overlay::persistence::load_overlay_data().unwrap_or_default();
+                if !overlay_data.proposals.is_empty()
+                    || overlay_data
+                        .monitor_overrides
+                        .iter()
+                        .any(|m| m.color_scheme.is_some())
+                {
+                    let mut overrides = config_overlay::persistence::proposals_to_overrides(
+                        overlay_data.proposals,
+                    );
+                    let config_monitor_overrides =
+                        config_overlay::data::to_config_monitor_overrides(
+                            &overlay_data.monitor_overrides,
+                        );
+                    if !config_monitor_overrides.is_empty() {
+                        if let wezterm_dynamic::Value::Object(ref mut obj) = overrides {
+                            use wezterm_dynamic::ToDynamic;
+                            obj.insert(
+                                wezterm_dynamic::Value::String(
+                                    "monitor_overrides".to_string(),
+                                ),
+                                config_monitor_overrides.to_dynamic(),
+                            );
+                        }
+                    }
+                    if overrides != wezterm_dynamic::Value::default() {
+                        myself.config_overrides = overrides;
+                        myself.config_was_reloaded();
+                    }
+                    // If we already know which monitor we're on, re-apply
+                    // monitor overrides now that the config includes them.
+                    if let Some(ref screen) = myself.current_screen_name.clone() {
+                        myself.apply_monitor_overrides(screen);
+                    }
+                }
+            }
+            // --- end weezterm remote features ---
         }
 
         crate::update::start_update_checker();
@@ -2548,15 +2592,27 @@ impl TermWindow {
         let tab_id = tab.tab_id();
         // --- weezterm remote features ---
         let current_screen = self.current_screen_name.clone();
-        let screen_names: Vec<String> = {
+        let screen_info_map: std::collections::HashMap<String, ::window::screen::ScreenInfo> = {
             use ::window::ConnectionOps;
             ::window::Connection::get()
                 .and_then(|conn| conn.screens().ok())
-                .map(|screens| screens.by_name.keys().cloned().collect())
+                .map(|screens| screens.by_name)
                 .unwrap_or_default()
         };
-        let monitor_entries =
-            data::monitors_from_config_with_screens(&screen_names, current_screen.as_deref());
+        let mut monitor_entries =
+            data::monitors_from_config_with_screens(&screen_info_map, current_screen.as_deref());
+        // Merge saved overlay monitor overrides into monitor entries so that
+        // previously-saved color scheme assignments show up in the overlay.
+        for saved in &overlay_data.monitor_overrides {
+            if let Some(entry) = monitor_entries
+                .iter_mut()
+                .find(|e| e.monitor_name == saved.monitor_name)
+            {
+                if entry.color_scheme.is_none() {
+                    entry.color_scheme = saved.color_scheme.clone();
+                }
+            }
+        }
         // --- end weezterm remote features ---
         let (overlay, future) = start_overlay(self, &tab, move |_tab_id, term| {
             config_overlay::run_config_overlay(
@@ -2623,8 +2679,24 @@ impl TermWindow {
                         }
                     }
 
-                    // Apply proposals as window config overrides
-                    let overrides = config_overlay::persistence::proposals_to_overrides(proposals);
+                    // Apply proposals + monitor overrides as window config overrides
+                    // --- weezterm remote features ---
+                    let config_monitor_overrides =
+                        config_overlay::data::to_config_monitor_overrides(&monitor_overrides);
+                    let mut overrides =
+                        config_overlay::persistence::proposals_to_overrides(proposals);
+                    // Inject monitor_overrides into the overrides object so the
+                    // running config picks them up via SetConfigOverrides.
+                    if !config_monitor_overrides.is_empty() {
+                        if let wezterm_dynamic::Value::Object(ref mut obj) = overrides {
+                            use wezterm_dynamic::ToDynamic;
+                            obj.insert(
+                                wezterm_dynamic::Value::String("monitor_overrides".to_string()),
+                                config_monitor_overrides.to_dynamic(),
+                            );
+                        }
+                    }
+                    // --- end weezterm remote features ---
                     window_clone.notify(TermWindowNotif::SetConfigOverrides(overrides));
                 }
                 Ok(config_overlay::ConfigOverlayAction::Preview(proposals)) => {

--- a/window/examples/async.rs
+++ b/window/examples/async.rs
@@ -91,8 +91,7 @@ impl MyWindow {
             | WindowEvent::MouseLeave
             | WindowEvent::SetInnerSizeCompleted => {}
             // --- weezterm remote features ---
-            WindowEvent::ScreenChanged { .. } => {}
-            // --- end weezterm remote features ---
+            WindowEvent::ScreenChanged { .. } => {} // --- end weezterm remote features ---
         }
     }
 }

--- a/window/examples/async.rs
+++ b/window/examples/async.rs
@@ -90,6 +90,9 @@ impl MyWindow {
             | WindowEvent::PerformKeyAssignment(_)
             | WindowEvent::MouseLeave
             | WindowEvent::SetInnerSizeCompleted => {}
+            // --- weezterm remote features ---
+            WindowEvent::ScreenChanged { .. } => {}
+            // --- end weezterm remote features ---
         }
     }
 }

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -216,6 +216,14 @@ pub enum WindowEvent {
     PerformKeyAssignment(config::keyassignment::KeyAssignment),
 
     AdviseModifiersLedStatus(Modifiers, KeyboardLedStatus),
+
+    // --- weezterm remote features ---
+    /// Called when the window moves to a different monitor.
+    /// `screen_name` is the friendly/localized name of the new monitor.
+    ScreenChanged {
+        screen_name: String,
+    },
+    // --- end weezterm remote features ---
 }
 
 pub struct WindowEventSender {

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -502,6 +502,9 @@ impl Window {
                 ime_last_event: None,
                 live_resizing: false,
                 ime_text: String::new(),
+                // --- weezterm remote features ---
+                current_monitor_name: None,
+                // --- end weezterm remote features ---
             }));
 
             let window: id = msg_send![get_window_class(), alloc];
@@ -1572,6 +1575,10 @@ struct Inner {
     live_resizing: bool,
 
     ime_text: String,
+
+    // --- weezterm remote features ---
+    current_monitor_name: Option<String>,
+    // --- end weezterm remote features ---
 }
 
 #[repr(C)]
@@ -3055,6 +3062,34 @@ impl WindowView {
                 // event that will in turn trigger an invalidation
                 // and a repaint.
                 inner.screen_changed = false;
+
+                // --- weezterm remote features ---
+                // Detect the new monitor name and emit ScreenChanged if it changed
+                if let Some(ref window) = inner.window {
+                    let window = window.load();
+                    let ns_screen: id = unsafe { msg_send![*window, screen] };
+                    if !ns_screen.is_null() {
+                        let screen_info =
+                            crate::os::macos::connection::nsscreen_to_screen_info(ns_screen);
+                        let changed = match &inner.current_monitor_name {
+                            Some(old) => old != &screen_info.name,
+                            None => true,
+                        };
+                        if changed {
+                            log::debug!(
+                                "macOS monitor changed: {:?} -> {:?}",
+                                inner.current_monitor_name,
+                                screen_info.name
+                            );
+                            inner.current_monitor_name = Some(screen_info.name.clone());
+                            inner.events.dispatch(WindowEvent::ScreenChanged {
+                                screen_name: screen_info.name,
+                            });
+                        }
+                    }
+                }
+                // --- end weezterm remote features ---
+
                 drop(inner);
                 Self::did_resize(view, sel, nil);
                 return;

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -330,6 +330,9 @@ impl WaylandWindow {
 
             wegl_surface: None,
             gl_state: None,
+            // --- weezterm remote features ---
+            current_monitor_name: None,
+            // --- end weezterm remote features ---
         }));
 
         let window_handle = Window::Wayland(WaylandWindow(window_id));
@@ -596,6 +599,9 @@ pub struct WaylandWindowInner {
     // libraries will segfault on shutdown
     wegl_surface: Option<WlEglSurface>,
     gl_state: Option<Rc<glium::backend::Context>>,
+    // --- weezterm remote features ---
+    current_monitor_name: Option<String>,
+    // --- end weezterm remote features ---
 }
 
 impl WaylandWindowInner {
@@ -1399,9 +1405,43 @@ impl CompositorHandler for WaylandState {
         &mut self,
         _conn: &WConnection,
         _qh: &wayland_client::QueueHandle<Self>,
-        _surface: &wayland_client::protocol::wl_surface::WlSurface,
-        _output: &wayland_client::protocol::wl_output::WlOutput,
+        surface: &wayland_client::protocol::wl_surface::WlSurface,
+        output: &wayland_client::protocol::wl_output::WlOutput,
     ) {
+        // --- weezterm remote features ---
+        // When the surface enters an output, detect the monitor name and
+        // emit ScreenChanged if it differs from the current monitor.
+        use smithay_client_toolkit::output::OutputState;
+        let output_name = self.output.info(output).and_then(|info| {
+            info.name
+                .clone()
+                .or_else(|| Some(format!("{} {}", info.model, info.make)))
+        });
+        if let Some(name) = output_name {
+            if let Some(surface_data) = SurfaceUserData::try_from_wl(surface) {
+                let window_id = surface_data.window_id;
+                let name_clone = name.clone();
+                WaylandConnection::with_window_inner(window_id, move |inner| {
+                    let changed = match &inner.current_monitor_name {
+                        Some(old) => old != &name_clone,
+                        None => true,
+                    };
+                    if changed {
+                        log::debug!(
+                            "Wayland monitor changed: {:?} -> {:?}",
+                            inner.current_monitor_name,
+                            name_clone
+                        );
+                        inner.current_monitor_name = Some(name_clone.clone());
+                        inner.events.dispatch(WindowEvent::ScreenChanged {
+                            screen_name: name_clone,
+                        });
+                    }
+                    Ok(())
+                });
+            }
+        }
+        // --- end weezterm remote features ---
     }
 
     fn surface_leave(

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -127,6 +127,11 @@ pub(crate) struct WindowInner {
     config: ConfigHandle,
     paint_throttled: bool,
     invalidated: bool,
+    // --- weezterm remote features ---
+    /// Tracks the friendly name of the monitor the window is currently on,
+    /// so we can emit `ScreenChanged` when it moves to a different monitor.
+    current_monitor_name: Option<String>,
+    // --- end weezterm remote features ---
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -286,6 +291,49 @@ impl WindowInner {
         }
     }
 
+    // --- weezterm remote features ---
+    /// Resolve the friendly monitor name for the monitor this window is currently on.
+    fn current_monitor_name_now(&self) -> Option<String> {
+        unsafe {
+            let mut mi: MONITORINFOEXW = std::mem::zeroed();
+            mi.cbSize = std::mem::size_of::<MONITORINFOEXW>() as u32;
+            let mon = MonitorFromWindow(self.hwnd.0, MONITOR_DEFAULTTONEAREST);
+            if mon.is_null() {
+                return None;
+            }
+            GetMonitorInfoW(mon, &mut mi as *mut MONITORINFOEXW as *mut MONITORINFO);
+
+            if let Ok(info) = crate::os::windows::connection::ScreenInfoHelper::new() {
+                Some(info.monitor_name(&mi))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Check if the window has moved to a different monitor and emit
+    /// `WindowEvent::ScreenChanged` if so.
+    fn check_and_emit_screen_changed(&mut self) {
+        if let Some(new_name) = self.current_monitor_name_now() {
+            let changed = match &self.current_monitor_name {
+                Some(old_name) => old_name != &new_name,
+                None => true,
+            };
+            if changed {
+                log::debug!(
+                    "Monitor changed: {:?} -> {:?}",
+                    self.current_monitor_name,
+                    new_name
+                );
+                self.current_monitor_name = Some(new_name.clone());
+                self.events.dispatch(WindowEvent::ScreenChanged {
+                    screen_name: new_name,
+                });
+            }
+        }
+    }
+    // --- end weezterm remote features ---
+
     /// Check if we need to generate a resize callback.
     /// Calls resize if needed.
     /// Returns true if we did.
@@ -336,6 +384,11 @@ impl WindowInner {
                 live_resizing: self.in_size_move,
             });
         }
+
+        // --- weezterm remote features ---
+        // Detect if the window has moved to a different monitor
+        self.check_and_emit_screen_changed();
+        // --- end weezterm remote features ---
 
         !same
     }
@@ -547,6 +600,9 @@ impl Window {
             config: config.clone(),
             paint_throttled: false,
             invalidated: true,
+            // --- weezterm remote features ---
+            current_monitor_name: None,
+            // --- end weezterm remote features ---
         }));
 
         // Careful: `raw` owns a ref to inner, but there is no Drop impl

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -110,6 +110,9 @@ pub(crate) struct XWindowInner {
     dragging: bool,
     outstanding_configure_requests: usize,
     pending_finished_resizes: usize,
+    // --- weezterm remote features ---
+    current_monitor_name: Option<String>,
+    // --- end weezterm remote features ---
 }
 
 /// <https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm46409506331616>
@@ -484,6 +487,9 @@ impl XWindowInner {
         self.update_ime_position();
 
         let mut dpi = conn.default_dpi();
+        // --- weezterm remote features ---
+        let mut detected_screen_name: Option<String> = None;
+        // --- end weezterm remote features ---
 
         if !self.config.dpi_by_screen.is_empty() {
             let coords = conn
@@ -514,12 +520,69 @@ impl XWindowInner {
                 .ok_or_else(|| anyhow::anyhow!("window is not in any screen"))?
                 .0;
 
+            // --- weezterm remote features ---
+            detected_screen_name = Some(screen.name.clone());
+            // --- end weezterm remote features ---
+
             if let Some(value) = self.config.dpi_by_screen.get(&screen.name).copied() {
                 dpi = value;
             } else if let Some(value) = self.config.dpi {
                 dpi = value;
             }
         }
+
+        // --- weezterm remote features ---
+        // If dpi_by_screen was empty, we still need to detect the screen
+        // for monitor override support. Do a lightweight screen lookup.
+        if detected_screen_name.is_none() {
+            if let Ok(coords) = conn.send_and_wait_request(&xcb::x::TranslateCoordinates {
+                src_window: self.window_id,
+                dst_window: conn.root,
+                src_x: 0,
+                src_y: 0,
+            }) {
+                if let Ok(screens) = conn.get_cached_screens() {
+                    let window_rect: ScreenRect = euclid::rect(
+                        coords.dst_x().into(),
+                        coords.dst_y().into(),
+                        width as isize,
+                        height as isize,
+                    );
+                    if let Some((screen, _)) = screens
+                        .by_name
+                        .values()
+                        .filter_map(|screen| {
+                            screen
+                                .rect
+                                .intersection(&window_rect)
+                                .map(|r| (screen, r.area()))
+                        })
+                        .max_by_key(|s| s.1)
+                    {
+                        detected_screen_name = Some(screen.name.clone());
+                    }
+                }
+            }
+        }
+        // Emit ScreenChanged if the monitor changed
+        if let Some(ref name) = detected_screen_name {
+            let changed = match &self.current_monitor_name {
+                Some(old) => old != name,
+                None => true,
+            };
+            if changed {
+                log::debug!(
+                    "X11 monitor changed: {:?} -> {:?}",
+                    self.current_monitor_name,
+                    name
+                );
+                self.current_monitor_name = Some(name.clone());
+                self.queue_pending(WindowEvent::ScreenChanged {
+                    screen_name: name.clone(),
+                });
+            }
+        }
+        // --- end weezterm remote features ---
 
         if width == self.width && height == self.height && dpi == self.dpi {
             // Effectively unchanged; perhaps it was simply moved?
@@ -1499,6 +1562,9 @@ impl XWindow {
                 dragging: false,
                 outstanding_configure_requests: 0,
                 pending_finished_resizes: 0,
+                // --- weezterm remote features ---
+                current_monitor_name: None,
+                // --- end weezterm remote features ---
             }))
         };
 


### PR DESCRIPTION
## Changes

### Config overlay field status fix
- Moved \set_lua_config_keys()\ before overrides are applied so \lua_set_fields\ only contains genuine Lua keys
- Added \overlay_keys\ from \config-overlay.json\ to correctly classify fields as \OverlayModified\ vs \FixedByLua\

### Monitor section restructure
- Restructured Monitors section with expandable grouped headers (like SSH domains)
- Each monitor shows as a collapsible group with Color Scheme as a child field

### Monitor layout diagram
- ASCII layout diagram in the details panel showing physical monitor arrangement
- Uses connection-based border rendering for proper junction characters (┬ ┴ ├ ┤ ┼) at shared edges
- Numbers match monitor list, ◆ marks current monitor, selected monitor highlighted

### Monitor override persistence
- Merge saved overlay monitor overrides on overlay open
- Include \monitor_overrides\ in \SetConfigOverrides\ on save
- Apply saved overlay data (proposals + monitor overrides) at window startup
- Re-apply monitor color scheme override for current screen at startup

### Interaction fixes
- Fix mouse click passthrough from command palette
- Add scroll wheel and click support in monitor scheme picker
- Fix expand/collapse behavior on click (same double-click pattern as SSH domains)

### Files changed
- \config/src/config.rs\ — Move \set_lua_config_keys()\ before overrides
- \wezterm-gui/src/overlay/config_overlay/data.rs\ — Add \MonitorRect\, \xpanded\ field, screen geometry
- \wezterm-gui/src/overlay/config_overlay/mod.rs\ — Monitor grouping, picker, click handlers
- \wezterm-gui/src/overlay/config_overlay/persistence.rs\ — \xpanded\/\screen_rect\ fields
- \wezterm-gui/src/overlay/config_overlay/render.rs\ — Monitor headers, layout diagram renderer
- \wezterm-gui/src/termwindow/mod.rs\ — Startup persistence, monitor override application