### PR TITLE
feat: fix window resize, startup rendering, and state persistence

### DIFF
--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -398,6 +398,16 @@ impl Pane for ClientPane {
             || inner.dimensions.pixel_width != size.pixel_width
             || inner.dimensions.pixel_height != size.pixel_height
         {
+            // --- weezterm remote features ---
+            log::debug!(
+                "ClientPane::resize: pane {} sending resize RPC: {}x{} -> {}x{}",
+                self.remote_pane_id,
+                inner.dimensions.cols,
+                inner.dimensions.viewport_rows,
+                cols,
+                rows,
+            );
+            // --- end weezterm remote features ---
             inner.dimensions.cols = cols;
             inner.dimensions.viewport_rows = rows;
             inner.dimensions.pixel_width = size.pixel_width;
@@ -421,6 +431,15 @@ impl Pane for ClientPane {
             })
             .detach();
             inner.update_last_send();
+        // --- weezterm remote features ---
+        } else {
+            log::debug!(
+                "ClientPane::resize: pane {} skipped (dims unchanged: {}x{})",
+                self.remote_pane_id,
+                cols,
+                rows,
+            );
+            // --- end weezterm remote features ---
         }
         Ok(())
     }

--- a/wezterm-client/src/pane/renderable.rs
+++ b/wezterm-client/src/pane/renderable.rs
@@ -349,7 +349,25 @@ impl RenderableInner {
         {
             self.cursor_position = delta.cursor_position;
         }
-        self.dimensions = delta.dimensions;
+        // --- weezterm remote features ---
+        // Don't overwrite dimensions from a server push when a local resize
+        // was recently sent. The client-side resize (from ClientPane::resize)
+        // takes precedence until the server acknowledges it. Without this,
+        // the server push can overwrite the intended new dimensions, causing
+        // a subsequent ClientPane::resize() to think no change is needed.
+        let recent_local_resize =
+            now.duration_since(self.last_send_time) < std::time::Duration::from_millis(500);
+        if recent_local_resize {
+            log::debug!(
+                "apply_changes_to_surface: skipping server dimension update for pane {} \
+                 (local resize pending, last_send {}ms ago)",
+                self.local_pane_id,
+                now.duration_since(self.last_send_time).as_millis(),
+            );
+        } else {
+            self.dimensions = delta.dimensions;
+        }
+        // --- end weezterm remote features ---
         self.title = delta.title;
         self.working_dir = delta.working_dir.map(Into::into);
         log::trace!(

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -57,6 +57,9 @@ mod unicode_names;
 mod uniforms;
 mod update;
 mod utilsprites;
+// --- weezterm remote features ---
+mod window_state_persistence;
+// --- end weezterm remote features ---
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -811,6 +811,10 @@ impl TermWindow {
         let mut x = None;
         let mut y = None;
         let mut origin = GeometryOrigin::default();
+        // --- weezterm remote features ---
+        let mut saved_maximized = false;
+        let mut saved_fullscreen = false;
+        // --- end weezterm remote features ---
 
         if let Some(position) = mux
             .get_window(mux_window_id)
@@ -820,6 +824,24 @@ impl TermWindow {
             x.replace(position.x);
             y.replace(position.y);
             origin = position.origin;
+        // --- weezterm remote features ---
+        } else {
+            // No CLI position specified; try loading saved window state
+            let workspace = mux
+                .get_window(mux_window_id)
+                .map(|w| w.get_workspace().to_string())
+                .unwrap_or_else(|| mux.active_workspace());
+            if let Some(saved) = crate::window_state_persistence::load_window_state(&workspace) {
+                x.replace(Dimension::Pixels(saved.x as f32));
+                y.replace(Dimension::Pixels(saved.y as f32));
+                origin = GeometryOrigin::ScreenCoordinateSystem;
+                // Override dimensions from saved state
+                dimensions.pixel_width = saved.width;
+                dimensions.pixel_height = saved.height;
+                saved_maximized = saved.maximized;
+                saved_fullscreen = saved.fullscreen;
+            }
+            // --- end weezterm remote features ---
         }
 
         let geometry = RequestedWindowGeometry {
@@ -899,6 +921,17 @@ impl TermWindow {
             }
             myself.load_os_parameters();
             window.show();
+            // --- weezterm remote features ---
+            // Restore maximized/fullscreen state from saved window state.
+            // This must happen after show() so the window is visible first.
+            if saved_maximized {
+                log::debug!("Restoring maximized state from saved window state");
+                window.maximize();
+            } else if saved_fullscreen {
+                log::debug!("Restoring fullscreen state from saved window state");
+                window.toggle_fullscreen();
+            }
+            // --- end weezterm remote features ---
             myself.subscribe_to_pane_updates();
             myself.emit_window_event("window-config-reloaded", None);
             myself.emit_status_event();
@@ -959,6 +992,10 @@ impl TermWindow {
         log::debug!("{event:?}");
         match event {
             WindowEvent::Destroyed => {
+                // --- weezterm remote features ---
+                // Save window state before destruction for future restore.
+                self.save_current_window_state();
+                // --- end weezterm remote features ---
                 // Ensure that we cancel any overlays we had running, so
                 // that the mux can empty out, otherwise the mux keeps
                 // the TermWindow alive via the frontend even though
@@ -1336,10 +1373,35 @@ impl TermWindow {
                             || size.pixel_width != self.terminal_size.pixel_width
                             || size.pixel_height != self.terminal_size.pixel_height
                         {
-                            self.set_window_size(size, window)?;
-                        } else if tab_size.dpi == 0 {
-                            log::debug!("fixup dpi in newly added tab");
+                            // --- weezterm remote features ---
+                            // When window can't resize (maximized/fullscreen),
+                            // don't try to grow the window — just resize the tab
+                            // to match the current window terminal size.
+                            if !self.window_state.can_resize() {
+                                log::debug!(
+                                    "TabAddedToWindow: window is {:?}, resizing tab {} to match window {:?}",
+                                    self.window_state,
+                                    tab_id,
+                                    self.terminal_size,
+                                );
+                                tab.resize(self.terminal_size);
+                            } else {
+                                self.set_window_size(size, window)?;
+                            }
+                            // --- end weezterm remote features ---
+                        } else {
+                            // --- weezterm remote features ---
+                            // Always resize tab to match window, regardless of DPI.
+                            // Previously this only happened when tab_size.dpi == 0,
+                            // but remote tabs typically have non-zero DPI and would
+                            // stay at their remote size.
+                            log::debug!(
+                                "TabAddedToWindow: resizing tab {} to match window {:?}",
+                                tab_id,
+                                self.terminal_size,
+                            );
                             tab.resize(self.terminal_size);
+                            // --- end weezterm remote features ---
                         }
                     }
                 }
@@ -1903,6 +1965,30 @@ impl TermWindow {
         self.invalidate_modal();
         self.emit_window_event("window-config-reloaded", None);
     }
+
+    // --- weezterm remote features ---
+    /// Save the current window state (position, size, maximized, monitor)
+    /// to disk for future restore on reconnect/restart.
+    fn save_current_window_state(&self) {
+        let mux = Mux::get();
+        let workspace = mux
+            .get_window(self.mux_window_id)
+            .map(|w| w.get_workspace().to_string())
+            .unwrap_or_else(|| mux.active_workspace());
+
+        let state = crate::window_state_persistence::SavedWindowState {
+            x: 0, // Will be overridden below if we can get position
+            y: 0,
+            width: self.dimensions.pixel_width,
+            height: self.dimensions.pixel_height,
+            maximized: self.window_state.contains(WindowState::MAXIMIZED),
+            fullscreen: self.window_state.contains(WindowState::FULL_SCREEN),
+            monitor: self.current_screen_name.clone(),
+        };
+
+        crate::window_state_persistence::save_window_state(&workspace, state);
+    }
+    // --- end weezterm remote features ---
 
     // --- weezterm remote features ---
     /// Called when the window moves to a different monitor.

--- a/wezterm-gui/src/termwindow/render/draw.rs
+++ b/wezterm-gui/src/termwindow/render/draw.rs
@@ -20,6 +20,28 @@ impl crate::TermWindow {
     fn call_draw_webgpu(&mut self) -> anyhow::Result<()> {
         use crate::termwindow::webgpu::WebGpuTexture;
 
+        // --- weezterm remote features ---
+        // Compute clear color before borrowing webgpu/render_state
+        let window_is_transparent_webgpu =
+            !self.window_background.is_empty() || self.config.window_background_opacity != 1.0;
+        let clear_color = if window_is_transparent_webgpu {
+            wgpu::Color {
+                r: 0.,
+                g: 0.,
+                b: 0.,
+                a: 0.,
+            }
+        } else {
+            let bg = self.palette().background.to_linear();
+            wgpu::Color {
+                r: bg.0 as f64,
+                g: bg.1 as f64,
+                b: bg.2 as f64,
+                a: 1.0,
+            }
+        };
+        // --- end weezterm remote features ---
+
         let webgpu = self.webgpu.as_mut().unwrap();
         let render_state = self.render_state.as_ref().unwrap();
 
@@ -104,12 +126,9 @@ impl crate::TermWindow {
                                 load: if cleared {
                                     wgpu::LoadOp::Load
                                 } else {
-                                    wgpu::LoadOp::Clear(wgpu::Color {
-                                        r: 0.,
-                                        g: 0.,
-                                        b: 0.,
-                                        a: 0.,
-                                    })
+                                    // --- weezterm remote features ---
+                                    wgpu::LoadOp::Clear(clear_color)
+                                    // --- end weezterm remote features ---
                                 },
                                 store: wgpu::StoreOp::Store,
                             },
@@ -152,11 +171,24 @@ impl crate::TermWindow {
     fn call_draw_glium(&mut self, frame: &mut glium::Frame) -> anyhow::Result<()> {
         use window::glium::texture::SrgbTexture2d;
 
+        // --- weezterm remote features ---
+        // Use the theme's background color as the clear color instead of
+        // transparent black, so the first frame (and every frame) starts with
+        // the correct background. This prevents the transparent-window-with-
+        // black-box artifact on startup.
+        let window_is_transparent_glium =
+            !self.window_background.is_empty() || self.config.window_background_opacity != 1.0;
+        if window_is_transparent_glium {
+            frame.clear_color(0., 0., 0., 0.);
+        } else {
+            let bg = self.palette().background.to_linear();
+            frame.clear_color(bg.0, bg.1, bg.2, 1.0);
+        }
+        // --- end weezterm remote features ---
+
         let gl_state = self.render_state.as_ref().unwrap();
         let tex = gl_state.glyph_cache.borrow().atlas.texture();
         let tex = tex.downcast_ref::<SrgbTexture2d>().unwrap();
-
-        frame.clear_color(0., 0., 0., 0.);
 
         let projection = euclid::Transform3D::<f32, f32, f32>::ortho(
             -(self.dimensions.pixel_width as f32) / 2.0,

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -27,7 +27,8 @@ impl super::TermWindow {
         window: &Window,
         live_resizing: bool,
     ) {
-        log::trace!(
+        // --- weezterm remote features ---
+        log::debug!(
             "resize event, live={} current cells: {:?}, current dims: {:?}, new dims: {:?} window_state:{:?}",
             live_resizing,
             self.current_cell_dimensions(),
@@ -35,6 +36,7 @@ impl super::TermWindow {
             dimensions,
             window_state,
         );
+        // --- end weezterm remote features ---
         if dimensions.pixel_width == 0 || dimensions.pixel_height == 0 {
             // on windows, this can happen when minimizing the window.
             // NOP!
@@ -151,6 +153,13 @@ impl super::TermWindow {
                 self.window_state
             );
             scale_changed_cells.take();
+            // --- weezterm remote features ---
+            // When window can't resize (maximized/fullscreen), the dimensions
+            // parameter may be synthetic (from set_window_size). Restore to
+            // the actual window dimensions to prevent corruption that would
+            // cause subsequent resize events to NOP.
+            self.dimensions = saved_dims;
+            // --- end weezterm remote features ---
         }
 
         // Technically speaking, we should compute the rows and cols
@@ -288,15 +297,35 @@ impl super::TermWindow {
             (size, *dimensions, ri_calc)
         };
 
-        log::trace!("apply_dimensions computed size {:?}, dims {:?}", size, dims);
+        // --- weezterm remote features ---
+        log::debug!("apply_dimensions computed size {:?}, dims {:?}", size, dims);
+        // --- end weezterm remote features ---
 
         self.terminal_size = size;
 
         let mux = Mux::get();
         if let Some(window) = mux.get_window(self.mux_window_id) {
+            // --- weezterm remote features ---
+            let tab_count = window.len();
+            // --- end weezterm remote features ---
             for tab in window.iter() {
+                // --- weezterm remote features ---
+                log::debug!(
+                    "apply_dimensions: resizing tab {} to {:?} (window has {} tabs)",
+                    tab.tab_id(),
+                    size,
+                    tab_count,
+                );
+                // --- end weezterm remote features ---
                 tab.resize(size);
             }
+        // --- weezterm remote features ---
+        } else {
+            log::warn!(
+                "apply_dimensions: mux.get_window({}) returned None, tabs NOT resized!",
+                self.mux_window_id,
+            );
+            // --- end weezterm remote features ---
         };
         self.resize_overlays();
         self.invalidate_fancy_tab_bar();

--- a/wezterm-gui/src/window_state_persistence.rs
+++ b/wezterm-gui/src/window_state_persistence.rs
@@ -1,0 +1,125 @@
+//! Persistence for window state (position, size, maximized/fullscreen, monitor).
+//!
+//! Saves and loads window geometry to/from a JSON file in the config directory
+//! so windows reopen in the same position and state across restarts/reconnects.
+//!
+//! --- weezterm remote features ---
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+const WINDOW_STATE_FILE: &str = "window-state.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedWindowState {
+    /// X position (screen coordinates) of the normal (restored) window
+    pub x: isize,
+    /// Y position (screen coordinates) of the normal (restored) window
+    pub y: isize,
+    /// Width of the normal (restored) window in pixels
+    pub width: usize,
+    /// Height of the normal (restored) window in pixels
+    pub height: usize,
+    /// Whether the window was maximized
+    #[serde(default)]
+    pub maximized: bool,
+    /// Whether the window was in fullscreen mode
+    #[serde(default)]
+    pub fullscreen: bool,
+    /// Name of the monitor the window was on
+    #[serde(default)]
+    pub monitor: Option<String>,
+}
+
+/// Returns the path to the window state file.
+fn state_file_path() -> Option<std::path::PathBuf> {
+    config::CONFIG_DIRS
+        .first()
+        .map(|dir| dir.join(WINDOW_STATE_FILE))
+}
+
+/// Load all saved window states from disk.
+fn load_all_states() -> HashMap<String, SavedWindowState> {
+    let path = match state_file_path() {
+        Some(p) => p,
+        None => return HashMap::new(),
+    };
+
+    if !path.exists() {
+        return HashMap::new();
+    }
+
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(err) => {
+            log::warn!("Failed to read window state file: {}", err);
+            HashMap::new()
+        }
+    }
+}
+
+/// Save all window states to disk.
+fn save_all_states(states: &HashMap<String, SavedWindowState>) {
+    let path = match state_file_path() {
+        Some(p) => p,
+        None => return,
+    };
+
+    match serde_json::to_string_pretty(states) {
+        Ok(json) => {
+            if let Err(err) = std::fs::write(&path, json) {
+                log::warn!("Failed to write window state file: {}", err);
+            }
+        }
+        Err(err) => {
+            log::warn!("Failed to serialize window state: {}", err);
+        }
+    }
+}
+
+/// Load the saved window state for a specific workspace.
+pub fn load_window_state(workspace: &str) -> Option<SavedWindowState> {
+    let states = load_all_states();
+    let state = states.get(workspace).cloned();
+
+    if let Some(ref s) = state {
+        // Validate that the saved position is reasonable (on some screen)
+        // by checking for extreme negative coordinates or zero dimensions
+        if s.width == 0 || s.height == 0 {
+            log::debug!(
+                "Ignoring saved window state for '{}': zero dimensions",
+                workspace
+            );
+            return None;
+        }
+        log::debug!(
+            "Loaded window state for '{}': {}x{} at ({},{}) maximized={} monitor={:?}",
+            workspace,
+            s.width,
+            s.height,
+            s.x,
+            s.y,
+            s.maximized,
+            s.monitor,
+        );
+    }
+
+    state
+}
+
+/// Save the window state for a specific workspace.
+pub fn save_window_state(workspace: &str, state: SavedWindowState) {
+    log::debug!(
+        "Saving window state for '{}': {}x{} at ({},{}) maximized={} monitor={:?}",
+        workspace,
+        state.width,
+        state.height,
+        state.x,
+        state.y,
+        state.maximized,
+        state.monitor,
+    );
+    let mut states = load_all_states();
+    states.insert(workspace.to_string(), state);
+    save_all_states(&states);
+}


### PR DESCRIPTION
## Summary

Three fixes for window management:

### 1. Fix Resize for Maximized/Snap/Non-Focused Tabs
- **Bug A**: \TabAddedToWindow\ skipped resizing remote tabs when \	ab_size.dpi != 0\ — tab stayed at remote size instead of matching the local window. Fixed by always resizing the tab to match the window regardless of DPI.
- **Bug B**: \set_window_size()\ on a maximized window corrupted \self.dimensions\ with synthetic pixel dimensions (not the actual window size), causing subsequent resize events to NOP. Fixed by restoring \self.dimensions\ from \saved_dims\ when \scale_changed_cells\ is taken due to \!can_resize()\.
- **Bug C**: Server push in \pply_changes_to_surface()\ unconditionally overwrote client-side resize dimensions (\enderable.rs:352\), creating a race where non-active pane resizes got lost. Fixed by skipping the server dimension overwrite when a recent local resize is pending (within 500ms of \last_send_time\).
- Added diagnostic \log::debug!\ throughout the resize flow.

### 2. Fix Startup Black Box
Changed GL clear color from transparent \(0,0,0,0)\ to the theme's background color in both Glium and WebGPU rendering paths. Preserves transparency semantics when \window_background_opacity < 1.0\.

### 3. Window State Persistence
New \window-state.json\ file (following \config-overlay.json\ pattern) saves and restores per-workspace:
- Window position (x, y) and size (width, height)
- Maximized/fullscreen state
- Monitor name

Restored on window creation when no CLI \--position\ is specified. Maximized/fullscreen state is applied after \window.show()\.

## Files Changed
- \wezterm-client/src/pane/clientpane.rs\ — Resize logging
- \wezterm-client/src/pane/renderable.rs\ — Race condition fix
- \wezterm-gui/src/main.rs\ — Module registration
- \wezterm-gui/src/termwindow/mod.rs\ — Tab resize fix, state save/restore
- \wezterm-gui/src/termwindow/render/draw.rs\ — Clear color fix
- \wezterm-gui/src/termwindow/resize.rs\ — Dimensions corruption fix, logging
- \wezterm-gui/src/window_state_persistence.rs\ — New persistence module