### PR TITLE
Prefer branded config and fix Wayland titlebars

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1031,18 +1031,8 @@ impl Config {
         // so we do this bit "by-hand"
 
         // --- weezterm remote features ---
-        // Check branded WeezTerm config names first, then fall back to
-        // upstream-compatible WezTerm config names.
-        let mut paths = vec![
-            PathPossibility::optional(HOME_DIR.join(".weezterm.lua")),
-            PathPossibility::optional(HOME_DIR.join(".wezterm.lua")),
-        ];
-        for dir in CONFIG_DIRS.iter() {
-            paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
-            paths.push(PathPossibility::optional(dir.join("wezterm.lua")))
-        }
-        // --- end weezterm remote features ---
-
+        let mut paths = vec![];
+        let mut portable_config_dir = None;
         if cfg!(windows) {
             // On Windows, a common use case is to maintain a thumb drive
             // with a set of portable tools that don't need to be installed
@@ -1054,13 +1044,18 @@ impl Config {
             // dir as the executable that will take precedence.
             if let Ok(exe_name) = std::env::current_exe() {
                 if let Some(exe_dir) = exe_name.parent() {
-                    paths.insert(0, PathPossibility::optional(exe_dir.join("wezterm.lua")));
-                    // --- weezterm remote features ---
-                    paths.insert(0, PathPossibility::optional(exe_dir.join("weezterm.lua")));
-                    // --- end weezterm remote features ---
+                    portable_config_dir = Some(exe_dir.to_path_buf());
                 }
             }
         }
+        add_default_config_file_candidates(
+            &mut paths,
+            &HOME_DIR,
+            &CONFIG_DIRS,
+            portable_config_dir.as_deref(),
+        );
+        // --- end weezterm remote features ---
+
         // --- weezterm remote features ---
         if let Some(path) = crate::branding::get_env_with_compat("CONFIG_FILE") {
             log::trace!(
@@ -1090,7 +1085,12 @@ impl Config {
                     }
                 }
                 Ok(None) => continue,
-                Ok(Some(loaded)) => return loaded,
+                Ok(Some(loaded)) => {
+                    if let Some(path) = loaded.file_name.as_ref() {
+                        log::debug!("Loaded configuration from {}", path.display());
+                    }
+                    return loaded;
+                }
             }
         }
 
@@ -2091,6 +2091,65 @@ impl PathPossibility {
         }
     }
 }
+
+// --- weezterm remote features ---
+fn add_default_config_file_candidates(
+    paths: &mut Vec<PathPossibility>,
+    home_dir: &Path,
+    config_dirs: &[PathBuf],
+    portable_config_dir: Option<&Path>,
+) {
+    // Branded WeezTerm names win over upstream-compatible WezTerm names.
+    if let Some(dir) = portable_config_dir {
+        paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
+    }
+    paths.push(PathPossibility::optional(home_dir.join(".weezterm.lua")));
+    for dir in config_dirs {
+        paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
+    }
+
+    if let Some(dir) = portable_config_dir {
+        paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
+    }
+    paths.push(PathPossibility::optional(home_dir.join(".wezterm.lua")));
+    for dir in config_dirs {
+        paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
+    }
+}
+
+#[cfg(test)]
+mod weezterm_config_file_tests {
+    use super::*;
+
+    #[test]
+    fn branded_config_paths_precede_legacy_paths() {
+        let home = Path::new("/home/user");
+        let dirs = vec![
+            PathBuf::from("/xdg/weezterm"),
+            PathBuf::from("/xdg/wezterm"),
+        ];
+        let portable = Path::new("/portable");
+        let mut paths = vec![];
+
+        add_default_config_file_candidates(&mut paths, home, &dirs, Some(portable));
+
+        let actual: Vec<PathBuf> = paths.into_iter().map(|path| path.path).collect();
+        assert_eq!(
+            actual,
+            vec![
+                PathBuf::from("/portable/weezterm.lua"),
+                PathBuf::from("/home/user/.weezterm.lua"),
+                PathBuf::from("/xdg/weezterm/weezterm.lua"),
+                PathBuf::from("/xdg/wezterm/weezterm.lua"),
+                PathBuf::from("/portable/wezterm.lua"),
+                PathBuf::from("/home/user/.wezterm.lua"),
+                PathBuf::from("/xdg/weezterm/wezterm.lua"),
+                PathBuf::from("/xdg/wezterm/wezterm.lua"),
+            ]
+        );
+    }
+}
+// --- end weezterm remote features ---
 
 /// Behavior when the program spawned by wezterm terminates
 #[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2103,12 +2103,14 @@ fn add_default_config_file_candidates(
 ) {
     if let Some(dir) = portable_config_dir {
         paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
-        paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
     }
 
     let (user_dirs, system_dirs) = split_user_and_system_config_dirs(config_dirs);
     paths.push(PathPossibility::optional(home_dir.join(".weezterm.lua")));
     add_config_dir_candidates(paths, &user_dirs);
+    if let Some(dir) = portable_config_dir {
+        paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
+    }
     paths.push(PathPossibility::optional(home_dir.join(".wezterm.lua")));
     add_config_dir_candidates(paths, &system_dirs);
 }
@@ -2195,12 +2197,12 @@ mod weezterm_config_file_tests {
             actual,
             vec![
                 PathBuf::from("/portable/weezterm.lua"),
-                PathBuf::from("/portable/wezterm.lua"),
                 PathBuf::from("/home/user/.weezterm.lua"),
                 PathBuf::from("/xdg/weezterm/weezterm.lua"),
                 PathBuf::from("/xdg/weezterm/wezterm.lua"),
                 PathBuf::from("/xdg/wezterm/weezterm.lua"),
                 PathBuf::from("/xdg/wezterm/wezterm.lua"),
+                PathBuf::from("/portable/wezterm.lua"),
                 PathBuf::from("/home/user/.wezterm.lua"),
                 PathBuf::from("/etc/xdg/weezterm/weezterm.lua"),
                 PathBuf::from("/etc/xdg/weezterm/wezterm.lua"),

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1031,14 +1031,14 @@ impl Config {
         // so we do this bit "by-hand"
 
         // --- weezterm remote features ---
-        // Check .weezterm.lua first, then fall back to .wezterm.lua.
-        // CONFIG_DIRS already includes both weezterm and wezterm directories,
-        // so we just search for wezterm.lua in each (the dir name provides the branding).
+        // Check branded WeezTerm config names first, then fall back to
+        // upstream-compatible WezTerm config names.
         let mut paths = vec![
             PathPossibility::optional(HOME_DIR.join(".weezterm.lua")),
             PathPossibility::optional(HOME_DIR.join(".wezterm.lua")),
         ];
         for dir in CONFIG_DIRS.iter() {
+            paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
             paths.push(PathPossibility::optional(dir.join("wezterm.lua")))
         }
         // --- end weezterm remote features ---
@@ -1055,6 +1055,9 @@ impl Config {
             if let Ok(exe_name) = std::env::current_exe() {
                 if let Some(exe_dir) = exe_name.parent() {
                     paths.insert(0, PathPossibility::optional(exe_dir.join("wezterm.lua")));
+                    // --- weezterm remote features ---
+                    paths.insert(0, PathPossibility::optional(exe_dir.join("weezterm.lua")));
+                    // --- end weezterm remote features ---
                 }
             }
         }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1086,9 +1086,11 @@ impl Config {
                 }
                 Ok(None) => continue,
                 Ok(Some(loaded)) => {
+                    // --- weezterm remote features ---
                     if let Some(path) = loaded.file_name.as_ref() {
-                        log::debug!("Loaded configuration from {}", path.display());
+                        log::debug!("Loaded configuration from {}", config_path_for_log(path));
                     }
+                    // --- end weezterm remote features ---
                     return loaded;
                 }
             }
@@ -2099,29 +2101,75 @@ fn add_default_config_file_candidates(
     config_dirs: &[PathBuf],
     portable_config_dir: Option<&Path>,
 ) {
-    // Branded WeezTerm names win over upstream-compatible WezTerm names.
     if let Some(dir) = portable_config_dir {
         paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
-    }
-    paths.push(PathPossibility::optional(home_dir.join(".weezterm.lua")));
-    for dir in config_dirs {
-        paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
-    }
-    for dir in config_dirs.iter().filter(|dir| is_branded_config_dir(dir)) {
         paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
     }
 
-    if let Some(dir) = portable_config_dir {
-        paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
-    }
+    let (user_dirs, system_dirs) = split_user_and_system_config_dirs(config_dirs);
+    paths.push(PathPossibility::optional(home_dir.join(".weezterm.lua")));
+    add_config_dir_candidates(paths, &user_dirs);
     paths.push(PathPossibility::optional(home_dir.join(".wezterm.lua")));
-    for dir in config_dirs.iter().filter(|dir| !is_branded_config_dir(dir)) {
+    add_config_dir_candidates(paths, &system_dirs);
+}
+
+fn split_user_and_system_config_dirs(config_dirs: &[PathBuf]) -> (Vec<&Path>, Vec<&Path>) {
+    let mut user_dirs = vec![];
+    let mut system_dirs = vec![];
+    let mut saw_branded_user = false;
+    let mut saw_legacy_user = false;
+
+    for dir in config_dirs {
+        if is_branded_config_dir(dir) && !saw_branded_user {
+            saw_branded_user = true;
+            user_dirs.push(dir.as_path());
+        } else if is_legacy_config_dir(dir) && !saw_legacy_user {
+            saw_legacy_user = true;
+            user_dirs.push(dir.as_path());
+        } else {
+            system_dirs.push(dir.as_path());
+        }
+    }
+
+    (user_dirs, system_dirs)
+}
+
+fn add_config_dir_candidates(paths: &mut Vec<PathPossibility>, dirs: &[&Path]) {
+    for dir in dirs {
+        paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
         paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
     }
 }
 
 fn is_branded_config_dir(dir: &Path) -> bool {
     dir.file_name().and_then(OsStr::to_str) == Some("weezterm")
+}
+
+fn is_legacy_config_dir(dir: &Path) -> bool {
+    dir.file_name().and_then(OsStr::to_str) == Some("wezterm")
+}
+
+fn config_path_for_log(path: &Path) -> String {
+    if let Ok(rel) = path.strip_prefix(&*HOME_DIR) {
+        return format!("~/{}", rel.display());
+    }
+
+    for dir in CONFIG_DIRS.iter() {
+        if let Ok(rel) = path.strip_prefix(dir) {
+            let label = if is_branded_config_dir(dir) {
+                "weezterm-config-dir"
+            } else if is_legacy_config_dir(dir) {
+                "wezterm-config-dir"
+            } else {
+                "config-dir"
+            };
+            return format!("{label}/{}", rel.display());
+        }
+    }
+
+    path.file_name()
+        .map(|name| format!("<{}>", name.to_string_lossy()))
+        .unwrap_or_else(|| "<config>".to_string())
 }
 
 #[cfg(test)]
@@ -2133,7 +2181,9 @@ mod weezterm_config_file_tests {
         let home = Path::new("/home/user");
         let dirs = vec![
             PathBuf::from("/xdg/weezterm"),
+            PathBuf::from("/etc/xdg/weezterm"),
             PathBuf::from("/xdg/wezterm"),
+            PathBuf::from("/etc/xdg/wezterm"),
         ];
         let portable = Path::new("/portable");
         let mut paths = vec![];
@@ -2145,13 +2195,17 @@ mod weezterm_config_file_tests {
             actual,
             vec![
                 PathBuf::from("/portable/weezterm.lua"),
+                PathBuf::from("/portable/wezterm.lua"),
                 PathBuf::from("/home/user/.weezterm.lua"),
                 PathBuf::from("/xdg/weezterm/weezterm.lua"),
-                PathBuf::from("/xdg/wezterm/weezterm.lua"),
                 PathBuf::from("/xdg/weezterm/wezterm.lua"),
-                PathBuf::from("/portable/wezterm.lua"),
-                PathBuf::from("/home/user/.wezterm.lua"),
+                PathBuf::from("/xdg/wezterm/weezterm.lua"),
                 PathBuf::from("/xdg/wezterm/wezterm.lua"),
+                PathBuf::from("/home/user/.wezterm.lua"),
+                PathBuf::from("/etc/xdg/weezterm/weezterm.lua"),
+                PathBuf::from("/etc/xdg/weezterm/wezterm.lua"),
+                PathBuf::from("/etc/xdg/wezterm/weezterm.lua"),
+                PathBuf::from("/etc/xdg/wezterm/wezterm.lua"),
             ]
         );
     }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2107,14 +2107,21 @@ fn add_default_config_file_candidates(
     for dir in config_dirs {
         paths.push(PathPossibility::optional(dir.join("weezterm.lua")));
     }
+    for dir in config_dirs.iter().filter(|dir| is_branded_config_dir(dir)) {
+        paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
+    }
 
     if let Some(dir) = portable_config_dir {
         paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
     }
     paths.push(PathPossibility::optional(home_dir.join(".wezterm.lua")));
-    for dir in config_dirs {
+    for dir in config_dirs.iter().filter(|dir| !is_branded_config_dir(dir)) {
         paths.push(PathPossibility::optional(dir.join("wezterm.lua")));
     }
+}
+
+fn is_branded_config_dir(dir: &Path) -> bool {
+    dir.file_name().and_then(OsStr::to_str) == Some("weezterm")
 }
 
 #[cfg(test)]
@@ -2141,9 +2148,9 @@ mod weezterm_config_file_tests {
                 PathBuf::from("/home/user/.weezterm.lua"),
                 PathBuf::from("/xdg/weezterm/weezterm.lua"),
                 PathBuf::from("/xdg/wezterm/weezterm.lua"),
+                PathBuf::from("/xdg/weezterm/wezterm.lua"),
                 PathBuf::from("/portable/wezterm.lua"),
                 PathBuf::from("/home/user/.wezterm.lua"),
-                PathBuf::from("/xdg/weezterm/wezterm.lua"),
                 PathBuf::from("/xdg/wezterm/wezterm.lua"),
             ]
         );

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -10,7 +10,7 @@ use mlua::{FromLua, IntoLuaMulti, Lua, Table, Value, Variadic};
 use ordered_float::NotNan;
 use portable_pty::CommandBuilder;
 use std::convert::TryFrom;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use wezterm_dynamic::{
     FromDynamic, FromDynamicOptions, ToDynamic, UnknownFieldAction, Value as DynValue,
@@ -228,12 +228,68 @@ pub fn make_lua_context(config_file: &Path) -> anyhow::Result<Lua> {
         }
 
         // --- weezterm remote features ---
-        prefix_path(&mut path_array, &crate::HOME_DIR.join(".weezterm"));
-        prefix_path(&mut path_array, &crate::HOME_DIR.join(".wezterm"));
-        // --- end weezterm remote features ---
-        for dir in crate::CONFIG_DIRS.iter() {
-            prefix_path(&mut path_array, dir);
+        fn is_named_dir(path: &Path, name: &str) -> bool {
+            path.file_name().and_then(|file_name| file_name.to_str()) == Some(name)
         }
+
+        fn split_user_and_system_dirs(dirs: &[PathBuf]) -> (Vec<PathBuf>, Vec<PathBuf>) {
+            let mut user_dirs = vec![];
+            let mut system_dirs = vec![];
+            let mut saw_weezterm = false;
+            let mut saw_wezterm = false;
+
+            for dir in dirs {
+                if is_named_dir(dir, "weezterm") && !saw_weezterm {
+                    saw_weezterm = true;
+                    user_dirs.push(dir.clone());
+                } else if is_named_dir(dir, "wezterm") && !saw_wezterm {
+                    saw_wezterm = true;
+                    user_dirs.push(dir.clone());
+                } else {
+                    system_dirs.push(dir.clone());
+                }
+            }
+
+            (user_dirs, system_dirs)
+        }
+
+        fn prefix_paths(array: &mut Vec<String>, paths: &[PathBuf]) {
+            for path in paths.iter().rev() {
+                prefix_path(array, path);
+            }
+        }
+
+        let (user_config_dirs, system_config_dirs) =
+            split_user_and_system_dirs(&crate::CONFIG_DIRS);
+        let mut module_dirs = vec![];
+        module_dirs.extend(
+            user_config_dirs
+                .iter()
+                .filter(|dir| is_named_dir(dir, "weezterm"))
+                .cloned(),
+        );
+        module_dirs.push(crate::HOME_DIR.join(".weezterm"));
+        module_dirs.extend(
+            user_config_dirs
+                .iter()
+                .filter(|dir| is_named_dir(dir, "wezterm"))
+                .cloned(),
+        );
+        module_dirs.push(crate::HOME_DIR.join(".wezterm"));
+        module_dirs.extend(
+            system_config_dirs
+                .iter()
+                .filter(|dir| is_named_dir(dir, "weezterm"))
+                .cloned(),
+        );
+        module_dirs.extend(
+            system_config_dirs
+                .iter()
+                .filter(|dir| is_named_dir(dir, "wezterm"))
+                .cloned(),
+        );
+        prefix_paths(&mut path_array, &module_dirs);
+        // --- end weezterm remote features ---
         path_array.insert(
             2,
             format!("{}/plugins/?/plugin/init.lua", crate::DATA_DIR.display()),

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -46,6 +46,13 @@ More complex configurations that need to span multiple files can be placed in
 `$XDG_CONFIG_HOME/wezterm/wezterm.lua` (for X11/Wayland) or
 `$HOME/.config/wezterm/wezterm.lua` (for all other systems).
 
+<!-- --- weezterm remote features --- -->
+For WeezTerm, branded config names are preferred:
+`$XDG_CONFIG_HOME/weezterm/weezterm.lua` or
+`$HOME/.config/weezterm/weezterm.lua`. If those files do not exist, WeezTerm
+falls back to upstream-compatible `wezterm.lua` locations.
+<!-- --- end weezterm remote features --- -->
+
 {% raw %}
 ```mermaid
 graph TD

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -38,19 +38,24 @@ For more details, see:
 `wezterm` will look for a [lua](https://www.lua.org/manual/5.3/manual.html)
 configuration file using the logic shown below.
 
+<!-- --- weezterm remote features --- -->
 !!! tip
-    The recommendation is to place your configuration file at `$HOME/.wezterm.lua`
-    (`%USERPROFILE%/.wezterm.lua` on Windows) to get started.
-
-More complex configurations that need to span multiple files can be placed in
-`$XDG_CONFIG_HOME/wezterm/wezterm.lua` (for X11/Wayland) or
-`$HOME/.config/wezterm/wezterm.lua` (for all other systems).
+    For WeezTerm, the recommendation is to place your configuration file at
+    `$HOME/.weezterm.lua`, or at `$XDG_CONFIG_HOME/weezterm/weezterm.lua` for
+    configurations that span multiple files. Legacy upstream-compatible
+    `.wezterm.lua` and `wezterm.lua` locations are still supported as fallbacks.
+<!-- --- end weezterm remote features --- -->
 
 <!-- --- weezterm remote features --- -->
-For WeezTerm, branded config names are preferred:
-`$XDG_CONFIG_HOME/weezterm/weezterm.lua` or
-`$HOME/.config/weezterm/weezterm.lua`. If those files do not exist, WeezTerm
-falls back to upstream-compatible `wezterm.lua` locations.
+More complex configurations that need to span multiple files can be placed in
+`$XDG_CONFIG_HOME/weezterm/weezterm.lua` (or
+`$HOME/.config/weezterm/weezterm.lua` when `XDG_CONFIG_HOME` is unset).
+<!-- --- end weezterm remote features --- -->
+
+<!-- --- weezterm remote features --- -->
+WeezTerm looks for branded config names first, then falls back to
+upstream-compatible WezTerm names. Explicit CLI and environment overrides still
+take precedence over automatic discovery.
 <!-- --- end weezterm remote features --- -->
 
 {% raw %}
@@ -60,16 +65,21 @@ graph TD
   A -->|Yes| B{{Can that file be loaded?}}
   B -->|Yes| C[Use it]
   B -->|No| D[Use built-in default configuration]
-  A -->|No| E{{$WEZTERM_CONFIG_FILE<br/>environment set?}}
+  A -->|No| E{{$WEEZTERM_CONFIG_FILE or<br/>$WEZTERM_CONFIG_FILE<br/>environment set?}}
   E -->|Yes| B
-  E -->|No| F{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as wezterm.exe?<br/>(Thumb drive mode)"}}
+  E -->|No| F{{"Running on Windows and<br/>weezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(Thumb drive mode)"}}
   F -->|Yes| B
-  F -->|No| H{{Is $XDG_CONFIG_HOME<br/>environment set and<br/>wezterm/wezterm.lua<br/>exists inside it?}}
+  F -->|No| G{{"$HOME/.weezterm.lua<br/>exists?"}}
+  G -->|Yes| B
+  G -->|No| H{{Does<br/>$XDG_CONFIG_HOME/weezterm/weezterm.lua<br/>or<br/>$HOME/.config/weezterm/weezterm.lua<br/>exist?}}
   H -->|Yes| B
-  J --> B
-  H -->|No| K{{Does $HOME/.config/wezterm/wezterm.lua exist?}}
+  H -->|No| I{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(legacy thumb drive mode)"}}
+  I -->|Yes| B
+  I -->|No| J{{"$HOME/.wezterm.lua<br/>exists?"}}
+  J -->|Yes| B
+  J -->|No| K{{Does a legacy<br/>wezterm/wezterm.lua<br/>config file exist?}}
   K -->|Yes| B
-  K -->|No| J[Use $HOME/.wezterm.lua]
+  K -->|No| L[Use built-in default configuration]
 ```
 {% endraw %}
 

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -1,8 +1,10 @@
 
 ## Quick Start
 
-Create a file named `.wezterm.lua` in your home directory, with the following
+<!-- --- weezterm remote features --- -->
+Create a file named `.weezterm.lua` in your home directory, with the following
 contents:
+<!-- --- end weezterm remote features --- -->
 
 ```lua
 -- Pull in the wezterm API
@@ -58,6 +60,7 @@ upstream-compatible WezTerm names. Explicit CLI and environment overrides still
 take precedence over automatic discovery.
 <!-- --- end weezterm remote features --- -->
 
+<!-- --- weezterm remote features --- -->
 {% raw %}
 ```mermaid
 graph TD
@@ -73,7 +76,9 @@ graph TD
   G -->|Yes| B
   G -->|No| H{{Does<br/>$XDG_CONFIG_HOME/weezterm/weezterm.lua<br/>or<br/>$HOME/.config/weezterm/weezterm.lua<br/>exist?}}
   H -->|Yes| B
-  H -->|No| I{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(legacy thumb drive mode)"}}
+  H -->|No| H2{{Does a branded config dir<br/>compat file<br/>weezterm/wezterm.lua exist?}}
+  H2 -->|Yes| B
+  H2 -->|No| I{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(legacy thumb drive mode)"}}
   I -->|Yes| B
   I -->|No| J{{"$HOME/.wezterm.lua<br/>exists?"}}
   J -->|Yes| B
@@ -82,6 +87,7 @@ graph TD
   K -->|No| L[Use built-in default configuration]
 ```
 {% endraw %}
+<!-- --- end weezterm remote features --- -->
 
 Prior to version 20210314-114017-04b7cedd, if the candidate file exists but
 failed to parse, wezterm would treat it as though it didn't exist and continue
@@ -94,6 +100,11 @@ error will be shown and the default configuration will be used instead.
     the same location as wezterm.exe.  That is shown in the chart above as thumb
     drive mode.  It is **not** recommended to store your configs in that
     location if you are not running off a thumb drive.
+
+<!-- --- weezterm remote features --- -->
+For WeezTerm, thumb-drive mode checks `weezterm.lua` next to `weezterm.exe`
+first, then falls back to the upstream-compatible `wezterm.lua` name.
+<!-- --- end weezterm remote features --- -->
 
 `wezterm` will watch the config file that it loads; if/when it changes, the
 configuration will be automatically reloaded and the majority of options will
@@ -188,18 +199,23 @@ config.color_scheme = 'Batman'
 If you'd like to break apart your configuration into multiple files, you'll
 be interested in this information.
 
-The Lua `package.path` is configured with the following paths in this order:
+<!-- --- weezterm remote features --- -->
+The Lua `package.path` is configured to include these WeezTerm locations:
 
-* On Windows: a `wezterm_modules` dir in the same directory as `wezterm.exe`. This is for thumb drive mode, and is not recommended to be used otherwise.
-* `~/.config/wezterm`
-* `~/.wezterm`
-* A system specific set of paths which may (or may not!) find locally installed lua modules
+* `$XDG_CONFIG_HOME/weezterm` or `~/.config/weezterm`
+* `~/.weezterm`
+* Legacy upstream-compatible `~/.config/wezterm` and `~/.wezterm` locations
+* On Windows: a `wezterm_modules` dir in the same directory as `weezterm.exe`. This is for thumb drive mode, and is not recommended to be used otherwise.
+* A system-specific set of paths which may (or may not!) find locally installed Lua modules
+<!-- --- end weezterm remote features --- -->
 
-That means that if you wanted to break your config up into a `helpers.lua` file
-you would place it in `~/.config/wezterm/helpers.lua` with contents like this:
+<!-- --- weezterm remote features --- -->
+That means that if you wanted to break your config up into a `helpers.lua` file,
+you would place it in `~/.config/weezterm/helpers.lua` with contents like this:
+<!-- --- end weezterm remote features --- -->
 
 ```lua
--- I am helpers.lua and I should live in ~/.config/wezterm/helpers.lua
+-- I am helpers.lua and I should live in ~/.config/weezterm/helpers.lua
 
 local wezterm = require 'wezterm'
 
@@ -228,8 +244,9 @@ end
 return module
 ```
 
-and then in your `wezterm.lua`
-you would use it like this:
+<!-- --- weezterm remote features --- -->
+and then in your `weezterm.lua` you would use it like this:
+<!-- --- end weezterm remote features --- -->
 
 ```lua
 local helpers = require 'helpers'

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -78,11 +78,11 @@ graph TD
   H -->|Yes| B
   H -->|No| H2{{Does a user config-dir<br/>compat file exist?<br/>weezterm/wezterm.lua,<br/>wezterm/weezterm.lua,<br/>or wezterm/wezterm.lua}}
   H2 -->|Yes| B
-  H2 -->|No| I{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(legacy thumb drive mode)"}}
+  H2 -->|No| I{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(legacy thumb drive fallback)"}}
   I -->|Yes| B
   I -->|No| J{{"$HOME/.wezterm.lua<br/>exists?"}}
   J -->|Yes| B
-  J -->|No| K{{Does a legacy<br/>wezterm/wezterm.lua<br/>config file exist?}}
+  J -->|No| K{{Does a system config-dir<br/>candidate exist?<br/>weezterm/weezterm.lua,<br/>weezterm/wezterm.lua,<br/>wezterm/weezterm.lua,<br/>or wezterm/wezterm.lua}}
   K -->|Yes| B
   K -->|No| L[Use built-in default configuration]
 ```
@@ -103,7 +103,8 @@ error will be shown and the default configuration will be used instead.
 
 <!-- --- weezterm remote features --- -->
 For WeezTerm, thumb-drive mode checks `weezterm.lua` next to `weezterm.exe`
-first, then falls back to the upstream-compatible `wezterm.lua` name.
+first. The upstream-compatible portable `wezterm.lua` name remains supported as
+a legacy fallback after branded user config locations.
 <!-- --- end weezterm remote features --- -->
 
 `wezterm` will watch the config file that it loads; if/when it changes, the
@@ -207,12 +208,8 @@ The Lua `package.path` is configured to include these WeezTerm locations:
 * Legacy upstream-compatible `~/.config/wezterm` and `~/.wezterm` locations
 * On Windows: a `wezterm_modules` dir in the same directory as `weezterm.exe`. This is for thumb drive mode, and is not recommended to be used otherwise.
 * A system-specific set of paths which may (or may not!) find locally installed Lua modules
-<!-- --- end weezterm remote features --- -->
-
-<!-- --- weezterm remote features --- -->
 That means that if you wanted to break your config up into a `helpers.lua` file,
 you would place it in `~/.config/weezterm/helpers.lua` with contents like this:
-<!-- --- end weezterm remote features --- -->
 
 ```lua
 -- I am helpers.lua and I should live in ~/.config/weezterm/helpers.lua
@@ -243,6 +240,7 @@ end
 -- return our module table
 return module
 ```
+<!-- --- end weezterm remote features --- -->
 
 <!-- --- weezterm remote features --- -->
 and then in your `weezterm.lua` you would use it like this:

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -76,7 +76,7 @@ graph TD
   G -->|Yes| B
   G -->|No| H{{Does<br/>$XDG_CONFIG_HOME/weezterm/weezterm.lua<br/>or<br/>$HOME/.config/weezterm/weezterm.lua<br/>exist?}}
   H -->|Yes| B
-  H -->|No| H2{{Does a branded config dir<br/>compat file<br/>weezterm/wezterm.lua exist?}}
+  H -->|No| H2{{Does a user config-dir<br/>compat file exist?<br/>weezterm/wezterm.lua,<br/>wezterm/weezterm.lua,<br/>or wezterm/wezterm.lua}}
   H2 -->|Yes| B
   H2 -->|No| I{{"Running on Windows and<br/>wezterm.lua exists in same<br/>dir as weezterm.exe?<br/>(legacy thumb drive mode)"}}
   I -->|Yes| B

--- a/docs/config/lua/config/window_decorations.md
+++ b/docs/config/lua/config/window_decorations.md
@@ -52,6 +52,14 @@ The value is a set of flags:
 
 On X11 and Wayland, the windowing system may override the window decorations.
 
+<!-- --- weezterm remote features --- -->
+On Wayland, WeezTerm requests server-side decorations for the default
+`TITLE | RESIZE` mode, but follows the compositor's negotiated decoration mode.
+If the compositor does not provide server-side titlebars, WeezTerm draws its
+client-side titlebar instead. If the compositor does provide server-side
+decorations, WeezTerm hides its client-side frame to avoid double titlebars.
+<!-- --- end weezterm remote features --- -->
+
 When the titlebar is disabled you can drag the window using the tab bar if it
 is enabled, or by holding down `SUPER` and dragging the window (on Windows:
 CTRL-SHIFT and drag the window).  You can map this dragging function for
@@ -76,4 +84,3 @@ desktop environment to resize the window.  Windows users may wish to consider
 
 !!! tip
     You probably always want `RESIZE` to be listed in your `window_decorations`.
-

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -249,17 +249,23 @@ impl WaylandWindow {
 
         let decor_mode = if decorations == WindowDecorations::NONE {
             None
+        } else if decorations == WindowDecorations::default() {
+            Some(DecorationMode::Server)
         // --- weezterm remote features ---
-        // Niri does not provide server-side titlebars; use WeezTerm's
-        // client-side frame whenever a titlebar is requested.
+        // Non-default titlebar modes need WeezTerm's client-side frame.
         } else if decorations.contains(WindowDecorations::TITLE) {
             Some(DecorationMode::Client)
         // --- end weezterm remote features ---
-        } else if decorations == WindowDecorations::default() {
-            Some(DecorationMode::Server)
         } else {
             Some(DecorationMode::Client)
         };
+        // --- weezterm remote features ---
+        log::debug!(
+            "Wayland requested decoration mode {:?} for {:?}",
+            decor_mode,
+            decorations
+        );
+        // --- end weezterm remote features ---
         window.request_decoration_mode(decor_mode);
 
         let mut window_frame = {
@@ -851,8 +857,14 @@ impl WaylandWindowInner {
 
         if let Some(ref window_config) = pending.window_configure {
             // --- weezterm remote features ---
-            let hide_client_decorations = window_config.decoration_mode == DecorationMode::Server;
+            let hide_client_decorations = self.config.window_decorations == WindowDecorations::NONE
+                || window_config.decoration_mode == DecorationMode::Server;
             if self.window_frame.is_hidden() != hide_client_decorations {
+                log::debug!(
+                    "Wayland compositor decoration mode {:?}; client frame hidden={}",
+                    window_config.decoration_mode,
+                    hide_client_decorations
+                );
                 self.window_frame.set_hidden(hide_client_decorations);
                 if !hide_client_decorations {
                     let width = NonZeroU32::new(

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -249,6 +249,12 @@ impl WaylandWindow {
 
         let decor_mode = if decorations == WindowDecorations::NONE {
             None
+        // --- weezterm remote features ---
+        // Niri does not provide server-side titlebars; use WeezTerm's
+        // client-side frame whenever a titlebar is requested.
+        } else if decorations.contains(WindowDecorations::TITLE) {
+            Some(DecorationMode::Client)
+        // --- end weezterm remote features ---
         } else if decorations == WindowDecorations::default() {
             Some(DecorationMode::Server)
         } else {

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -344,6 +344,7 @@ impl WaylandWindow {
             gl_state: None,
             // --- weezterm remote features ---
             current_monitor_name: None,
+            last_reported_decoration_state: None,
             // --- end weezterm remote features ---
         }));
 
@@ -613,6 +614,7 @@ pub struct WaylandWindowInner {
     gl_state: Option<Rc<glium::backend::Context>>,
     // --- weezterm remote features ---
     current_monitor_name: Option<String>,
+    last_reported_decoration_state: Option<(DecorationMode, bool)>,
     // --- end weezterm remote features ---
 }
 
@@ -859,12 +861,16 @@ impl WaylandWindowInner {
             // --- weezterm remote features ---
             let hide_client_decorations = self.config.window_decorations == WindowDecorations::NONE
                 || window_config.decoration_mode == DecorationMode::Server;
-            if self.window_frame.is_hidden() != hide_client_decorations {
+            let decoration_state = (window_config.decoration_mode, hide_client_decorations);
+            if self.last_reported_decoration_state != Some(decoration_state) {
                 log::debug!(
                     "Wayland compositor decoration mode {:?}; client frame hidden={}",
                     window_config.decoration_mode,
                     hide_client_decorations
                 );
+                self.last_reported_decoration_state = Some(decoration_state);
+            }
+            if self.window_frame.is_hidden() != hide_client_decorations {
                 self.window_frame.set_hidden(hide_client_decorations);
                 if !hide_client_decorations {
                     let width = NonZeroU32::new(
@@ -876,6 +882,14 @@ impl WaylandWindowInner {
                     )
                     .unwrap_or_else(|| NonZeroU32::new(1).unwrap());
                     self.window_frame.resize(width, height);
+                }
+                let (x, y) = self.window_frame.location();
+                let surface_width = self.pixels_to_surface(self.dimensions.pixel_width as i32);
+                let surface_height = self.pixels_to_surface(self.dimensions.pixel_height as i32);
+                if let Some(window) = self.window.as_mut() {
+                    window
+                        .xdg_surface()
+                        .set_window_geometry(x, y, surface_width, surface_height);
                 }
                 pending.refresh_decorations = true;
             }

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -652,7 +652,9 @@ impl WaylandWindowInner {
 
     fn refresh_frame(&mut self) {
         if self.window_frame.is_dirty() && !self.window_frame.is_hidden() {
-            self.window_frame.draw();
+            if self.window_frame.draw() {
+                self.surface().commit();
+            }
         }
     }
 
@@ -907,7 +909,7 @@ impl WaylandWindowInner {
             }
             if pending.configure.is_none() {
                 self.apply_current_window_geometry();
-                self.surface().commit();
+                pending.refresh_decorations = true;
             }
             // --- end weezterm remote features ---
             self.window_frame.update_state(window_config.state);

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -850,6 +850,24 @@ impl WaylandWindowInner {
         }
 
         if let Some(ref window_config) = pending.window_configure {
+            // --- weezterm remote features ---
+            let hide_client_decorations = window_config.decoration_mode == DecorationMode::Server;
+            if self.window_frame.is_hidden() != hide_client_decorations {
+                self.window_frame.set_hidden(hide_client_decorations);
+                if !hide_client_decorations {
+                    let width = NonZeroU32::new(
+                        self.pixels_to_surface(self.dimensions.pixel_width as i32) as u32,
+                    )
+                    .unwrap_or_else(|| NonZeroU32::new(1).unwrap());
+                    let height = NonZeroU32::new(
+                        self.pixels_to_surface(self.dimensions.pixel_height as i32) as u32,
+                    )
+                    .unwrap_or_else(|| NonZeroU32::new(1).unwrap());
+                    self.window_frame.resize(width, height);
+                }
+                pending.refresh_decorations = true;
+            }
+            // --- end weezterm remote features ---
             self.window_frame.update_state(window_config.state);
             self.window_frame
                 .update_wm_capabilities(window_config.capabilities);

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -656,6 +656,19 @@ impl WaylandWindowInner {
         }
     }
 
+    // --- weezterm remote features ---
+    fn apply_current_window_geometry(&self) {
+        let (x, y) = self.window_frame.location();
+        let surface_width = self.pixels_to_surface(self.dimensions.pixel_width as i32);
+        let surface_height = self.pixels_to_surface(self.dimensions.pixel_height as i32);
+        if let Some(window) = self.window.as_ref() {
+            window
+                .xdg_surface()
+                .set_window_geometry(x, y, surface_width, surface_height);
+        }
+    }
+    // --- end weezterm remote features ---
+
     fn enable_opengl(&mut self) -> anyhow::Result<Rc<glium::backend::Context>> {
         let wayland_conn = Connection::get().unwrap().wayland();
         let mut wegl_surface = None;
@@ -890,16 +903,11 @@ impl WaylandWindowInner {
                     .unwrap_or_else(|| NonZeroU32::new(1).unwrap());
                     self.window_frame.resize(width, height);
                 }
-                let (x, y) = self.window_frame.location();
-                let surface_width = self.pixels_to_surface(self.dimensions.pixel_width as i32);
-                let surface_height = self.pixels_to_surface(self.dimensions.pixel_height as i32);
-                if let Some(window) = self.window.as_mut() {
-                    window
-                        .xdg_surface()
-                        .set_window_geometry(x, y, surface_width, surface_height);
-                    self.surface().commit();
-                }
                 pending.refresh_decorations = true;
+            }
+            if pending.configure.is_none() {
+                self.apply_current_window_geometry();
+                self.surface().commit();
             }
             // --- end weezterm remote features ---
             self.window_frame.update_state(window_config.state);

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -238,14 +238,21 @@ impl WaylandWindow {
             dpi: config.dpi.unwrap_or(crate::DEFAULT_DPI) as usize,
         };
 
+        let decorations = config.window_decorations;
+        // --- weezterm remote features ---
+        let initial_decorations = if decorations == WindowDecorations::NONE {
+            Decorations::None
+        } else {
+            Decorations::RequestServer
+        };
+        // --- end weezterm remote features ---
         let window = {
             let xdg_shell = &conn.wayland_state.borrow().xdg;
-            xdg_shell.create_window(surface.clone(), Decorations::RequestServer, &qh)
+            xdg_shell.create_window(surface.clone(), initial_decorations, &qh)
         };
 
         window.set_app_id(class_name.to_string());
         window.set_title(name.to_string());
-        let decorations = config.window_decorations;
 
         let decor_mode = if decorations == WindowDecorations::NONE {
             None
@@ -890,6 +897,7 @@ impl WaylandWindowInner {
                     window
                         .xdg_surface()
                         .set_window_geometry(x, y, surface_width, surface_height);
+                    self.surface().commit();
                 }
                 pending.refresh_decorations = true;
             }


### PR DESCRIPTION
## Summary
- Prefer branded WeezTerm config/module paths before upstream-compatible fallbacks while preserving user-over-system and portable-mode ordering.
- Document branded config discovery, module paths, and Wayland decoration negotiation.
- Fix Wayland titlebar behavior by honoring compositor decoration mode, avoiding double titlebars, preserving `NONE`, and committing synced frame updates.

## Validation
- Panel review: software, test, nixos, networking, security, rust, product, docs, observability, and kernel all signed off after iterative fixes.
- `nix develop --command bash -lc 'cargo fmt --all -- --check && cargo test -p config branded_config_paths_precede_legacy_paths && cargo check -p config && cargo check -p window'`
- Config precedence smokes: `weezterm/weezterm.lua`, `weezterm/wezterm.lua`, and `wezterm/weezterm.lua` beat legacy `~/.wezterm.lua`.
- Lua module precedence smoke: branded helper beats legacy helper.
- Headless Weston smoke: `TITLE | RESIZE`, `NONE`, and `TITLE` Wayland configs launched successfully.