### PR TITLE
ci: scope release workflow write permissions

### DIFF
--- a/.github/workflows/weezterm_build.yml
+++ b/.github/workflows/weezterm_build.yml
@@ -17,7 +17,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -291,6 +291,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && !cancelled()
     needs: [windows, macos, linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -321,6 +323,8 @@ jobs:
     if: github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') && !cancelled()
     needs: [windows, macos, linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- keep the workflow default `GITHUB_TOKEN` at `contents: read`
- grant `contents: write` only to the tag release and dev pre-release jobs that publish artifacts

## Validation
- `git diff --check`
- `yq '.' .github/workflows/weezterm_build.yml`
