### PR TITLE
fix: correct Wayland titlebar client geometry

### DIFF
--- a/wezterm-gui/src/overlay/config_overlay/data.rs
+++ b/wezterm-gui/src/overlay/config_overlay/data.rs
@@ -909,6 +909,7 @@ pub fn value_to_display_string(v: &Value) -> String {
 }
 
 /// Compare two `Value`s for display equality (ignoring numeric type differences).
+#[allow(dead_code)]
 pub fn values_equal(a: &Value, b: &Value) -> bool {
     match (a, b) {
         (Value::Bool(a), Value::Bool(b)) => a == b,
@@ -1333,6 +1334,7 @@ pub fn devcontainers_from_config() -> Vec<DevContainerEntry> {
         .collect()
 }
 
+#[allow(dead_code)]
 pub fn to_config_devcontainer_domain(
     dc: &DevContainerOverlayConfig,
 ) -> config::devcontainer::DevContainerDomainConfig {

--- a/wezterm-gui/src/overlay/config_overlay/mod.rs
+++ b/wezterm-gui/src/overlay/config_overlay/mod.rs
@@ -19,7 +19,7 @@ pub mod theme;
 
 pub use data::{FieldDef, FieldKind, Section, SshDomainConfig};
 // --- weezterm remote features ---
-pub use data::{DevContainerOverlayConfig, MonitorOverrideEntry};
+pub use data::MonitorOverrideEntry;
 // --- end weezterm remote features ---
 
 /// Result returned by the config overlay to the caller.

--- a/wezterm-gui/src/overlay/config_overlay/persistence.rs
+++ b/wezterm-gui/src/overlay/config_overlay/persistence.rs
@@ -114,6 +114,7 @@ pub fn load_overlay_data() -> anyhow::Result<OverlayData> {
 }
 
 /// Load saved proposals from disk (backward-compatible wrapper).
+#[allow(dead_code)]
 pub fn load_proposals() -> anyhow::Result<HashMap<String, Value>> {
     Ok(load_overlay_data()?.proposals)
 }
@@ -186,6 +187,7 @@ pub fn save_overlay_data(
 }
 
 /// Save proposals to disk as JSON (backward-compatible wrapper).
+#[allow(dead_code)]
 pub fn save_proposals(proposals: &HashMap<String, Value>) -> anyhow::Result<()> {
     // Load existing data to preserve domains and monitor overrides
     let existing = load_overlay_data().unwrap_or(OverlayData {

--- a/wezterm-gui/src/overlay/devcontainer.rs
+++ b/wezterm-gui/src/overlay/devcontainer.rs
@@ -4,7 +4,7 @@
 //! Displays discovered devcontainers with interactive controls.
 //! Follows the TermWiz overlay pattern used by port_forward.rs.
 
-use mux::devcontainer_discover::{ContainerStatus, DevContainerInfo};
+use mux::devcontainer_discover::DevContainerInfo;
 use termwiz::cell::AttributeChange;
 use termwiz::color::AnsiColor;
 use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers};
@@ -13,6 +13,7 @@ use termwiz::terminal::Terminal;
 
 /// Actions that can result from the overlay interaction
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum DevContainerAction {
     Close,
     /// Connect to a container (open new tab)
@@ -45,7 +46,7 @@ pub enum DevContainerAction {
 pub fn run_devcontainer_overlay(
     mut term: impl Terminal,
     entries: Vec<DevContainerInfo>,
-    domain_name: String,
+    _domain_name: String,
     host_label: String,
     primary_container_id: Option<String>,
     default_workspace_folder: Option<String>,
@@ -55,7 +56,7 @@ pub fn run_devcontainer_overlay(
         selected: 0,
         filter: String::new(),
         primary_container_id,
-        domain_name,
+        _domain_name,
         host_label,
         expanded: None,
         create_input: None,
@@ -287,7 +288,7 @@ struct OverlayState {
     selected: usize,
     filter: String,
     primary_container_id: Option<String>,
-    domain_name: String,
+    _domain_name: String,
     host_label: String,
     expanded: Option<String>,
     create_input: Option<String>,

--- a/wezterm-gui/src/overlay/port_forward.rs
+++ b/wezterm-gui/src/overlay/port_forward.rs
@@ -242,6 +242,7 @@ pub fn run_port_forward_overlay(
 
 /// Actions that can result from the overlay interaction
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum PortForwardAction {
     Close,
     StartForward {

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -8,7 +8,7 @@ use crate::utilsprites::RenderMetrics;
 use config::{Dimension, DimensionContext, RgbaColor, TabBarColor, TabBarColors};
 use std::rc::Rc;
 use wezterm_font::LoadedFont;
-use wezterm_term::color::{ColorAttribute, ColorPalette, SrgbaTuple};
+use wezterm_term::color::{ColorPalette, SrgbaTuple};
 use window::{IntegratedTitleButtonAlignment, IntegratedTitleButtonStyle};
 
 // --- weezterm remote features ---
@@ -203,23 +203,6 @@ impl crate::TermWindow {
         let item_to_elem = |item: &TabEntry| -> Element {
             let element = Element::with_line(&font, &item.title, palette);
 
-            let bg_color = item
-                .title
-                .get_cell(0)
-                .and_then(|c| match c.attrs().background() {
-                    ColorAttribute::Default => None,
-                    col => Some(palette.resolve_bg(col)),
-                });
-            let fg_color = item
-                .title
-                .get_cell(0)
-                .and_then(|c| match c.attrs().foreground() {
-                    ColorAttribute::Default => None,
-                    col => Some(palette.resolve_fg(col)),
-                });
-
-            let new_tab = colors.new_tab();
-            let new_tab_hover = colors.new_tab_hover();
             let active_tab = colors.active_tab();
 
             match item.item {

--- a/wezterm-gui/src/termwindow/render/screen_line.rs
+++ b/wezterm-gui/src/termwindow/render/screen_line.rs
@@ -444,10 +444,6 @@ impl crate::TermWindow {
                 }
             };
 
-            // TODO: remember logical/visual mapping for selection
-            #[allow(unused_variables)]
-            let mut phys_cell_idx = cluster.first_cell_idx;
-
             // Pre-decrement by the cluster width when doing RTL,
             // so that we can render it right-justified
             if direction == Direction::RightToLeft {
@@ -674,7 +670,6 @@ impl crate::TermWindow {
                         }
                     }
                 }
-                phys_cell_idx += info.pos.num_cells as usize;
                 visual_cell_idx += info.pos.num_cells as usize;
                 cluster_x_pos += if params.use_pixel_positioning {
                     glyph.x_advance.get() as f32 * width_scale

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -1159,8 +1159,6 @@ impl WebGpuState {
             RawWindowHandle::Win32(h) => h.hwnd.get() as usize,
             _ => 0,
         };
-        #[cfg(not(windows))]
-        let wake_hwnd: usize = 0;
 
         let spawn_res = std::thread::Builder::new()
             .name("wgpu-async-configure".into())

--- a/window/src/os/wayland/mod.rs
+++ b/window/src/os/wayland/mod.rs
@@ -10,6 +10,9 @@ pub use output::*;
 mod copy_and_paste;
 mod drag_and_drop;
 // mod frame;
+// --- weezterm remote features ---
+mod titlebar_frame;
+// --- end weezterm remote features ---
 mod data_device;
 mod keyboard;
 mod pointer;

--- a/window/src/os/wayland/titlebar_frame.rs
+++ b/window/src/os/wayland/titlebar_frame.rs
@@ -1,0 +1,531 @@
+// --- weezterm remote features ---
+use std::error::Error;
+use std::marker::PhantomData;
+use std::mem;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::time::Duration;
+
+use smithay_client_toolkit::compositor::SurfaceData;
+use smithay_client_toolkit::reexports::client::protocol::wl_shm;
+use smithay_client_toolkit::reexports::client::protocol::wl_subsurface::WlSubsurface;
+use smithay_client_toolkit::reexports::client::protocol::wl_surface::WlSurface;
+use smithay_client_toolkit::reexports::client::{Dispatch, Proxy, QueueHandle};
+use smithay_client_toolkit::reexports::csd_frame::{
+    DecorationsFrame, FrameAction, FrameClick, WindowManagerCapabilities, WindowState,
+};
+use smithay_client_toolkit::seat::pointer::CursorIcon;
+use smithay_client_toolkit::shell::WaylandSurface;
+use smithay_client_toolkit::shm::slot::SlotPool;
+use smithay_client_toolkit::shm::Shm;
+use smithay_client_toolkit::subcompositor::{SubcompositorState, SubsurfaceData};
+use wayland_backend::client::ObjectId;
+
+const HEADER_SIZE: u32 = 24;
+
+const BTN_ICON_COLOR: u32 = 0xFFCCCCCC;
+const BTN_HOVER_BG: u32 = 0xFF808080;
+const PRIMARY_COLOR_ACTIVE: u32 = 0xFF3A3A3A;
+const PRIMARY_COLOR_INACTIVE: u32 = 0xFF242424;
+
+#[derive(Debug)]
+pub struct TitleBarFrame<State> {
+    parent: WlSurface,
+    state: WindowState,
+    wm_capabilities: WindowManagerCapabilities,
+    dirty: bool,
+    mouse_location: Location,
+    mouse_coords: (i32, i32),
+    render_data: Option<FrameRenderData>,
+    should_sync: bool,
+    scale_factor: f64,
+    queue_handle: QueueHandle<State>,
+    pool: SlotPool,
+    subcompositor: Arc<SubcompositorState>,
+    buttons: [Option<UIButton>; 3],
+    _state: PhantomData<State>,
+}
+
+impl<State> TitleBarFrame<State>
+where
+    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+{
+    pub fn new(
+        parent: &impl WaylandSurface,
+        shm: &Shm,
+        subcompositor: Arc<SubcompositorState>,
+        queue_handle: QueueHandle<State>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let parent = parent.wl_surface().clone();
+        let pool = SlotPool::new(1, shm)?;
+        let render_data = Some(FrameRenderData::new(&parent, &subcompositor, &queue_handle));
+        let wm_capabilities = WindowManagerCapabilities::all();
+
+        Ok(Self {
+            parent,
+            state: WindowState::empty(),
+            wm_capabilities,
+            dirty: true,
+            mouse_location: Location::None,
+            mouse_coords: (0, 0),
+            render_data,
+            should_sync: true,
+            scale_factor: 1.0,
+            queue_handle,
+            pool,
+            subcompositor,
+            buttons: Self::supported_buttons(wm_capabilities),
+            _state: PhantomData,
+        })
+    }
+
+    fn supported_buttons(wm_capabilities: WindowManagerCapabilities) -> [Option<UIButton>; 3] {
+        let maximize = wm_capabilities
+            .contains(WindowManagerCapabilities::MAXIMIZE)
+            .then_some(UIButton::Maximize);
+        let minimize = wm_capabilities
+            .contains(WindowManagerCapabilities::MINIMIZE)
+            .then_some(UIButton::Minimize);
+        [Some(UIButton::Close), maximize, minimize]
+    }
+
+    fn find_button(buttons: &[Option<UIButton>], x: f64, y: f64, width: u32) -> Location {
+        for (idx, &button) in buttons.iter().flatten().enumerate() {
+            let idx = idx as u32;
+            if width >= (idx + 1) * HEADER_SIZE
+                && x >= f64::from(width - (idx + 1) * HEADER_SIZE)
+                && x <= f64::from(width - idx * HEADER_SIZE)
+                && y <= f64::from(HEADER_SIZE)
+                && y >= 0.0
+            {
+                return Location::Button(button);
+            }
+        }
+
+        Location::Head
+    }
+
+    fn part_index_for_surface(&self, surface_id: &ObjectId) -> Option<usize> {
+        self.render_data
+            .as_ref()
+            .and_then(|data| (&data.header.surface.id() == surface_id).then_some(0))
+    }
+
+    fn draw_buttons(
+        buttons: &[Option<UIButton>],
+        canvas: &mut [u8],
+        width: u32,
+        scale: u32,
+        is_active: bool,
+        mouse_location: &Location,
+    ) {
+        let scale = scale as usize;
+        for (idx, &button) in buttons.iter().flatten().enumerate() {
+            if width >= (idx + 1) as u32 * HEADER_SIZE {
+                if is_active && mouse_location == &Location::Button(button) {
+                    Self::draw_button(
+                        canvas,
+                        idx * HEADER_SIZE as usize,
+                        scale,
+                        width as usize,
+                        BTN_HOVER_BG.to_le_bytes(),
+                    );
+                }
+                Self::draw_icon(
+                    canvas,
+                    width as usize,
+                    idx * HEADER_SIZE as usize,
+                    scale,
+                    BTN_ICON_COLOR.to_le_bytes(),
+                    button,
+                );
+            }
+        }
+    }
+
+    fn draw_button(
+        canvas: &mut [u8],
+        x_offset: usize,
+        scale: usize,
+        width: usize,
+        btn_color: [u8; 4],
+    ) {
+        let height = HEADER_SIZE as usize;
+        let x_start = width - height - x_offset;
+        for y in 0..height * scale {
+            let start = (x_start + y * width) * 4 * scale;
+            let end = (x_start + y * width + height) * scale * 4;
+            for pixel in canvas[start..end].chunks_exact_mut(4) {
+                pixel[0] = btn_color[0];
+                pixel[1] = btn_color[1];
+                pixel[2] = btn_color[2];
+                pixel[3] = btn_color[3];
+            }
+        }
+    }
+
+    fn draw_icon(
+        canvas: &mut [u8],
+        width: usize,
+        x_offset: usize,
+        scale: usize,
+        icon_color: [u8; 4],
+        icon: UIButton,
+    ) {
+        let height = HEADER_SIZE as usize;
+        let scaled_height = scale * height;
+        let x_start = width - height - x_offset;
+
+        match icon {
+            UIButton::Close => {
+                for y in scaled_height / 4..3 * scaled_height / 4 {
+                    let line = &mut canvas[(x_start + y * width + height / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * height / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel.copy_from_slice(&icon_color);
+                    }
+                }
+            }
+            UIButton::Maximize => {
+                for y in 2 * scaled_height / 8..3 * scaled_height / 8 {
+                    let line = &mut canvas[(x_start + y * width + height / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * height / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel.copy_from_slice(&icon_color);
+                    }
+                }
+                for y in 3 * scaled_height / 8..5 * scaled_height / 8 {
+                    let left = &mut canvas[(x_start + y * width + 2 * height / 8) * 4 * scale
+                        ..(x_start + y * width + 3 * height / 8) * 4 * scale];
+                    for pixel in left.chunks_exact_mut(4) {
+                        pixel.copy_from_slice(&icon_color);
+                    }
+                    let right = &mut canvas[(x_start + y * width + 5 * height / 8) * 4 * scale
+                        ..(x_start + y * width + 6 * height / 8) * 4 * scale];
+                    for pixel in right.chunks_exact_mut(4) {
+                        pixel.copy_from_slice(&icon_color);
+                    }
+                }
+                for y in 5 * scaled_height / 8..6 * scaled_height / 8 {
+                    let line = &mut canvas[(x_start + y * width + height / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * height / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel.copy_from_slice(&icon_color);
+                    }
+                }
+            }
+            UIButton::Minimize => {
+                for y in 5 * scaled_height / 8..3 * scaled_height / 4 {
+                    let line = &mut canvas[(x_start + y * width + height / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * height / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel.copy_from_slice(&icon_color);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<State> DecorationsFrame for TitleBarFrame<State>
+where
+    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+{
+    fn on_click(
+        &mut self,
+        _timestamp: Duration,
+        click: FrameClick,
+        pressed: bool,
+    ) -> Option<FrameAction> {
+        if click == FrameClick::Alternate {
+            return if self.mouse_location != Location::Head
+                || !self
+                    .wm_capabilities
+                    .contains(WindowManagerCapabilities::WINDOW_MENU)
+            {
+                None
+            } else {
+                Some(FrameAction::ShowMenu(
+                    self.mouse_coords.0,
+                    self.mouse_coords.1 - HEADER_SIZE as i32,
+                ))
+            };
+        }
+
+        match self.mouse_location {
+            Location::Head if pressed => Some(FrameAction::Move),
+            Location::Button(UIButton::Close) if !pressed => Some(FrameAction::Close),
+            Location::Button(UIButton::Minimize) if !pressed => Some(FrameAction::Minimize),
+            Location::Button(UIButton::Maximize)
+                if !pressed && !self.state.contains(WindowState::MAXIMIZED) =>
+            {
+                Some(FrameAction::Maximize)
+            }
+            Location::Button(UIButton::Maximize)
+                if !pressed && self.state.contains(WindowState::MAXIMIZED) =>
+            {
+                Some(FrameAction::UnMaximize)
+            }
+            _ => None,
+        }
+    }
+
+    fn click_point_moved(
+        &mut self,
+        _timestamp: Duration,
+        surface_id: &ObjectId,
+        x: f64,
+        y: f64,
+    ) -> Option<CursorIcon> {
+        self.part_index_for_surface(surface_id)?;
+        let old_location = self.mouse_location;
+        self.mouse_coords = (x as i32, y as i32);
+        let width = self.render_data.as_ref()?.header.width;
+        self.mouse_location = Self::find_button(&self.buttons, x, y, width);
+        self.dirty |= (matches!(old_location, Location::Button(_))
+            || matches!(self.mouse_location, Location::Button(_)))
+            && old_location != self.mouse_location;
+        Some(CursorIcon::Default)
+    }
+
+    fn click_point_left(&mut self) {
+        self.mouse_location = Location::None;
+        self.dirty = true;
+    }
+
+    fn update_state(&mut self, state: WindowState) {
+        let difference = self.state.symmetric_difference(state);
+        self.state = state;
+        self.dirty |= !difference
+            .intersection(WindowState::ACTIVATED | WindowState::FULLSCREEN | WindowState::MAXIMIZED)
+            .is_empty();
+    }
+
+    fn update_wm_capabilities(&mut self, wm_capabilities: WindowManagerCapabilities) {
+        self.dirty |= self.wm_capabilities != wm_capabilities;
+        self.wm_capabilities = wm_capabilities;
+        self.buttons = Self::supported_buttons(wm_capabilities);
+    }
+
+    fn resize(&mut self, width: NonZeroU32, _height: NonZeroU32) {
+        let render_data = self
+            .render_data
+            .as_mut()
+            .expect("trying to resize hidden frame");
+        render_data.header.width = width.get();
+        self.dirty = true;
+        self.should_sync = true;
+    }
+
+    fn set_scaling_factor(&mut self, scale_factor: f64) {
+        self.scale_factor = scale_factor;
+        self.dirty = true;
+        self.should_sync = true;
+    }
+
+    fn location(&self) -> (i32, i32) {
+        if self.state.contains(WindowState::FULLSCREEN) || self.is_hidden() {
+            (0, 0)
+        } else {
+            (0, -(HEADER_SIZE as i32))
+        }
+    }
+
+    fn subtract_borders(
+        &self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> (Option<NonZeroU32>, Option<NonZeroU32>) {
+        if self.state.contains(WindowState::FULLSCREEN) || self.is_hidden() {
+            (Some(width), Some(height))
+        } else {
+            (
+                Some(width),
+                NonZeroU32::new(height.get().saturating_sub(HEADER_SIZE)),
+            )
+        }
+    }
+
+    fn add_borders(&self, width: u32, height: u32) -> (u32, u32) {
+        if self.state.contains(WindowState::FULLSCREEN) || self.is_hidden() {
+            (width, height)
+        } else {
+            (width, height + HEADER_SIZE)
+        }
+    }
+
+    fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    fn set_hidden(&mut self, hidden: bool) {
+        if self.is_hidden() == hidden {
+            return;
+        }
+
+        if hidden {
+            self.render_data = None;
+        } else {
+            let _ = self.pool.resize(1);
+            self.render_data = Some(FrameRenderData::new(
+                &self.parent,
+                &self.subcompositor,
+                &self.queue_handle,
+            ));
+        }
+        self.dirty = true;
+        self.should_sync = true;
+    }
+
+    fn is_hidden(&self) -> bool {
+        self.render_data.is_none()
+    }
+
+    fn set_resizable(&mut self, _resizable: bool) {}
+
+    fn draw(&mut self) -> bool {
+        let render_data = match self.render_data.as_mut() {
+            Some(render_data) => render_data,
+            None => return false,
+        };
+
+        self.dirty = false;
+        let should_sync = mem::take(&mut self.should_sync);
+
+        if self.state.contains(WindowState::FULLSCREEN) {
+            render_data.header.surface.attach(None, 0, 0);
+            render_data.header.surface.commit();
+            return should_sync;
+        }
+
+        let is_active = self.state.contains(WindowState::ACTIVATED);
+        let fill_color = if is_active {
+            PRIMARY_COLOR_ACTIVE
+        } else {
+            PRIMARY_COLOR_INACTIVE
+        }
+        .to_le_bytes();
+        let scale = self.scale_factor.ceil() as i32;
+        let width = render_data.header.width;
+        let height = HEADER_SIZE;
+
+        let (buffer, canvas) = match self.pool.create_buffer(
+            width as i32 * scale,
+            height as i32 * scale,
+            width as i32 * 4 * scale,
+            wl_shm::Format::Argb8888,
+        ) {
+            Ok((buffer, canvas)) => (buffer, canvas),
+            Err(_) => return should_sync,
+        };
+
+        for pixel in canvas.chunks_exact_mut(4) {
+            pixel.copy_from_slice(&fill_color);
+        }
+
+        Self::draw_buttons(
+            &self.buttons,
+            canvas,
+            width,
+            scale as u32,
+            is_active,
+            &self.mouse_location,
+        );
+
+        render_data.header.surface.set_buffer_scale(scale);
+        if should_sync {
+            render_data.header.subsurface.set_sync();
+        } else {
+            render_data.header.subsurface.set_desync();
+        }
+        render_data
+            .header
+            .subsurface
+            .set_position(render_data.header.pos.0, render_data.header.pos.1);
+
+        if let Err(err) = buffer.attach_to(&render_data.header.surface) {
+            log::error!("failed to attach titlebar buffer: {err}");
+            return should_sync;
+        }
+        if render_data.header.surface.version() >= 4 {
+            render_data
+                .header
+                .surface
+                .damage_buffer(0, 0, i32::MAX, i32::MAX);
+        } else {
+            render_data.header.surface.damage(0, 0, i32::MAX, i32::MAX);
+        }
+        render_data.header.surface.commit();
+
+        should_sync
+    }
+
+    fn set_title(&mut self, _title: impl Into<String>) {}
+}
+
+#[derive(Debug)]
+struct FrameRenderData {
+    header: FramePart,
+}
+
+impl FrameRenderData {
+    fn new<State>(
+        parent: &WlSurface,
+        subcompositor: &SubcompositorState,
+        queue_handle: &QueueHandle<State>,
+    ) -> Self
+    where
+        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    {
+        Self {
+            header: FramePart::new(
+                subcompositor.create_subsurface(parent.clone(), queue_handle),
+                HEADER_SIZE,
+                (0, -(HEADER_SIZE as i32)),
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FramePart {
+    subsurface: WlSubsurface,
+    surface: WlSurface,
+    width: u32,
+    pos: (i32, i32),
+}
+
+impl FramePart {
+    fn new(surfaces: (WlSubsurface, WlSurface), width: u32, pos: (i32, i32)) -> Self {
+        let (subsurface, surface) = surfaces;
+        subsurface.set_sync();
+        Self {
+            subsurface,
+            surface,
+            width,
+            pos,
+        }
+    }
+}
+
+impl Drop for FramePart {
+    fn drop(&mut self) {
+        self.subsurface.destroy();
+        self.surface.destroy();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Location {
+    None,
+    Head,
+    Button(UIButton),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UIButton {
+    Close,
+    Maximize,
+    Minimize,
+}
+// --- end weezterm remote features ---

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -28,7 +28,6 @@ use smithay_client_toolkit::reexports::csd_frame::{
 };
 use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge as XdgResizeEdge;
 use smithay_client_toolkit::seat::pointer::CursorIcon;
-use smithay_client_toolkit::shell::xdg::fallback_frame::FallbackFrame;
 use smithay_client_toolkit::shell::xdg::window::{
     DecorationMode, Window as XdgWindow, WindowConfigure, WindowDecorations as Decorations,
     WindowHandler,
@@ -52,6 +51,9 @@ use wezterm_input_types::{
 
 use crate::wayland::WaylandConnection;
 use crate::x11::KeyboardWithFallback;
+// --- weezterm remote features ---
+use super::titlebar_frame::TitleBarFrame;
+// --- end weezterm remote features ---
 use crate::{
     Appearance, Clipboard, Connection, ConnectionOps, Dimensions, MouseCursor, Point, Rect,
     RequestedWindowGeometry, ResizeIncrement, ResolvedGeometry, Window, WindowEvent,
@@ -279,7 +281,7 @@ impl WaylandWindow {
             let wayland_state = &conn.wayland_state.borrow();
             let shm = &wayland_state.shm;
             let subcompositor = wayland_state.subcompositor.clone();
-            FallbackFrame::new(&window, shm, subcompositor, qh.clone())
+            TitleBarFrame::new(&window, shm, subcompositor, qh.clone())
                 .expect("failed to create csd frame")
         };
         let hidden = match decor_mode {
@@ -296,13 +298,19 @@ impl WaylandWindow {
             );
         }
 
-        window.set_min_size(Some((32, 32)));
+        let (min_width, min_height) = window_frame.add_borders(32, 32);
+        window.set_min_size(Some((min_width, min_height)));
         let (x, y) = window_frame.location();
-        let surface_width = dimensions.pixels_to_surface(dimensions.pixel_width as i32);
-        let surface_height = dimensions.pixels_to_surface(dimensions.pixel_height as i32);
-        window
-            .xdg_surface()
-            .set_window_geometry(x, y, surface_width, surface_height);
+        let surface_width = dimensions.pixels_to_surface(dimensions.pixel_width as i32) as u32;
+        let surface_height = dimensions.pixels_to_surface(dimensions.pixel_height as i32) as u32;
+        let (geometry_width, geometry_height) =
+            window_frame.add_borders(surface_width, surface_height);
+        window.xdg_surface().set_window_geometry(
+            x,
+            y,
+            geometry_width as i32,
+            geometry_height as i32,
+        );
         window.commit();
 
         let copy_and_paste = CopyAndPaste::create();
@@ -541,10 +549,35 @@ pub(crate) struct PendingEvent {
     refresh_decorations: bool,
     // XXX: configure and window_configure could probably be combined, but right now configure only
     // queues a new size, so it can be out of sync. Example would be maximizing and minimizing winodw
-    pub(crate) configure: Option<(u32, u32)>,
+    pub(crate) configure: Option<PendingConfigureSize>,
     pub(crate) window_configure: Option<WindowConfigure>,
     pub(crate) dpi: Option<i32>,
     pub(crate) window_state: Option<WindowState>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingConfigureSize {
+    width: u32,
+    height: u32,
+    is_window_geometry: bool,
+}
+
+impl PendingConfigureSize {
+    fn content(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            is_window_geometry: false,
+        }
+    }
+
+    fn window_geometry(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            is_window_geometry: true,
+        }
+    }
 }
 
 pub(crate) fn read_pipe_with_timeout(mut file: ReadPipe) -> anyhow::Result<String> {
@@ -591,7 +624,7 @@ pub struct WaylandWindowInner {
     surface_factor: f64,
     copy_and_paste: Arc<Mutex<CopyAndPaste>>,
     window: Option<XdgWindow>,
-    pub(super) window_frame: FallbackFrame<WaylandState>,
+    pub(super) window_frame: TitleBarFrame<WaylandState>,
     dimensions: Dimensions,
     resize_increments: Option<ResizeIncrement>,
     window_state: WindowState,
@@ -659,15 +692,24 @@ impl WaylandWindowInner {
     }
 
     // --- weezterm remote features ---
-    fn apply_current_window_geometry(&self) {
+    fn set_window_geometry_for_content(&self, surface_width: u32, surface_height: u32) {
         let (x, y) = self.window_frame.location();
-        let surface_width = self.pixels_to_surface(self.dimensions.pixel_width as i32);
-        let surface_height = self.pixels_to_surface(self.dimensions.pixel_height as i32);
+        let (geometry_width, geometry_height) =
+            self.window_frame.add_borders(surface_width, surface_height);
         if let Some(window) = self.window.as_ref() {
-            window
-                .xdg_surface()
-                .set_window_geometry(x, y, surface_width, surface_height);
+            window.xdg_surface().set_window_geometry(
+                x,
+                y,
+                geometry_width as i32,
+                geometry_height as i32,
+            );
         }
+    }
+
+    fn apply_current_window_geometry(&self) {
+        let surface_width = self.pixels_to_surface(self.dimensions.pixel_width as i32) as u32;
+        let surface_height = self.pixels_to_surface(self.dimensions.pixel_height as i32) as u32;
+        self.set_window_geometry_for_content(surface_width, surface_height);
     }
     // --- end weezterm remote features ---
 
@@ -871,7 +913,7 @@ impl WaylandWindowInner {
         if pending.configure.is_none() {
             if pending.dpi.is_some() {
                 // Synthesize a pending configure event for the dpi change
-                pending.configure.replace((
+                pending.configure.replace(PendingConfigureSize::content(
                     self.pixels_to_surface(self.dimensions.pixel_width as i32) as u32,
                     self.pixels_to_surface(self.dimensions.pixel_height as i32) as u32,
                 ));
@@ -880,6 +922,9 @@ impl WaylandWindowInner {
         }
 
         if let Some(ref window_config) = pending.window_configure {
+            self.window_frame.update_state(window_config.state);
+            self.window_frame
+                .update_wm_capabilities(window_config.capabilities);
             // --- weezterm remote features ---
             let hide_client_decorations = self.config.window_decorations == WindowDecorations::NONE
                 || window_config.decoration_mode == DecorationMode::Server;
@@ -912,12 +957,11 @@ impl WaylandWindowInner {
                 pending.refresh_decorations = true;
             }
             // --- end weezterm remote features ---
-            self.window_frame.update_state(window_config.state);
-            self.window_frame
-                .update_wm_capabilities(window_config.capabilities);
         }
 
-        if let Some((mut w, mut h)) = pending.configure.take() {
+        if let Some(configure) = pending.configure.take() {
+            let mut w = configure.width;
+            let mut h = configure.height;
             log::trace!("Pending configure: w:{w}, h{h} -- {:?}", self.window);
             if self.window.is_some() {
                 let surface_udata = SurfaceUserData::from_wl(self.surface());
@@ -929,6 +973,20 @@ impl WaylandWindowInner {
 
                 // Do this early because this affects surface_to_pixels/pixels_to_surface
                 self.dimensions.dpi = dpi;
+
+                if configure.is_window_geometry {
+                    let width = NonZeroU32::new(w).unwrap_or_else(|| NonZeroU32::new(1).unwrap());
+                    let height = NonZeroU32::new(h).unwrap_or_else(|| NonZeroU32::new(1).unwrap());
+                    let (content_width, content_height) =
+                        self.window_frame.subtract_borders(width, height);
+                    w = content_width
+                        .unwrap_or_else(|| NonZeroU32::new(1).unwrap())
+                        .get();
+                    h = content_height
+                        .unwrap_or_else(|| NonZeroU32::new(1).unwrap())
+                        .get();
+                    log::trace!("Pending configure content size after frame subtraction: {w}x{h}");
+                }
 
                 let mut pixel_width = self.surface_to_pixels(w.try_into().unwrap());
                 let mut pixel_height = self.surface_to_pixels(h.try_into().unwrap());
@@ -958,14 +1016,7 @@ impl WaylandWindowInner {
                     self.window_frame.resize(width, height);
                     pending.refresh_decorations = true
                 }
-                let (x, y) = self.window_frame.location();
-                let surface_width = self.pixels_to_surface(pixel_width);
-                let surface_height = self.pixels_to_surface(pixel_height);
-                self.window
-                    .as_mut()
-                    .unwrap()
-                    .xdg_surface()
-                    .set_window_geometry(x, y, surface_width, surface_height);
+                self.set_window_geometry_for_content(w, h);
                 // Compute the new pixel dimensions
                 let new_dimensions = Dimensions {
                     pixel_width: pixel_width.try_into().unwrap(),
@@ -1140,7 +1191,7 @@ impl WaylandWindowInner {
             .lock()
             .unwrap()
             .configure
-            .replace((surface_width, surface_height));
+            .replace(PendingConfigureSize::content(surface_width, surface_height));
         // apply the synthetic configure event to the inner surfaces
         self.dispatch_pending_event();
 
@@ -1394,7 +1445,9 @@ impl WaylandState {
                 pending_event.had_configure_event = true;
                 if let (Some(w), Some(h)) = configure.new_size {
                     changed = pending_event.configure.is_none();
-                    pending_event.configure.replace((w.get(), h.get()));
+                    pending_event
+                        .configure
+                        .replace(PendingConfigureSize::window_geometry(w.get(), h.get()));
                 } else {
                     changed = true;
                 }
@@ -1479,7 +1532,6 @@ impl CompositorHandler for WaylandState {
         // --- weezterm remote features ---
         // When the surface enters an output, detect the monitor name and
         // emit ScreenChanged if it differs from the current monitor.
-        use smithay_client_toolkit::output::OutputState;
         let output_name = self.output.info(output).and_then(|info| {
             info.name
                 .clone()


### PR DESCRIPTION
## Summary
- Replace the Wayland fallback CSD frame with a WeezTerm titlebar-only frame so niri/client-side decorations no longer draw side or bottom borders.
- Treat compositor configure sizes as Wayland window geometry and synthetic resize/DPI sizes as terminal content geometry, preventing the terminal surface from overflowing the visible window.
- Clean up Rust warnings surfaced by the GUI build.

## Validation
- `nix --extra-experimental-features 'nix-command flakes' develop -c cargo fmt --all -- --check`
- `nix --extra-experimental-features 'nix-command flakes' develop -c cargo check -p window --features wayland`
- `nix --extra-experimental-features 'nix-command flakes' develop -c cargo test -p window --features wayland`
- `nix --extra-experimental-features 'nix-command flakes' develop -c cargo build -p wezterm-gui`
- Real niri Wayland launch of rebuilt `target/debug/weezterm-gui` with isolated config/runtime. niri reported `window_size` 1262x1382; focused-window PNG was 1893x2073 at 1.5 scale; parsed terminal content bbox was `(0,55,1893,2073)`, confirming content reaches the right/bottom edges with only a top titlebar.

## Panel review
Final follow-up panel sign-off was unanimous (10/10): software, test, nixos, networking, security, rust, product, docs, observability, kernel.
