### PR TITLE
ci: add changelog-driven nix release workflow

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,30 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changelog-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check CHANGELOG.md updated
+        run: |
+          # If any code files changed, CHANGELOG.md must be updated too
+          code_changed=$(git diff --name-only origin/main...HEAD | grep -E '\.(rs|toml|nix|yml)$' | grep -v CHANGELOG || true)
+          changelog_changed=$(git diff --name-only origin/main...HEAD | grep 'CHANGELOG.md' || true)
+
+          if [ -n "$code_changed" ] && [ -z "$changelog_changed" ]; then
+            echo "ERROR: Code files changed but CHANGELOG.md was not updated."
+            echo "Changed code files:"
+            echo "$code_changed"
+            echo ""
+            echo "Please add an entry under '## [Unreleased]' in CHANGELOG.md."
+            exit 1
+          fi
+          echo "OK: CHANGELOG.md updated (or no code changes)"
+      - name: Validate CHANGELOG.md format
+        run: bash scripts/changelog-check.sh CHANGELOG.md

--- a/.github/workflows/nix_release.yml
+++ b/.github/workflows/nix_release.yml
@@ -102,3 +102,48 @@ jobs:
           gh release create "$VERSION" release/* \
             --title "$VERSION" \
             --notes "$NOTES"
+
+      - name: Install Nix (for hash computation)
+        uses: cachix/install-nix-action@v4
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Compute SRI hashes and commit prebuilt manifest
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.detect-version.outputs.version }}"
+          REPO="${{ github.repository }}"
+
+          mkdir -p nix
+          tarball=$(find release/ -name "*nix.tar.gz" | head -1)
+          if [ -z "$tarball" ]; then
+            tarball=$(find release/ -name "*.tar.gz" | head -1)
+          fi
+
+          if [ -n "$tarball" ] && [ -f "$tarball" ]; then
+            sri=$(nix hash file --type sha256 --sri "$tarball")
+            url="https://github.com/${REPO}/releases/download/v${VERSION}/$(basename "$tarball")"
+
+            cat > nix/prebuilt.json <<EOF
+          {
+            "version": "$VERSION",
+            "system": "x86_64-linux",
+            "binaries": {
+              "weezterm": {
+                "url": "$url",
+                "hash": "$sri"
+              }
+            }
+          }
+          EOF
+          fi
+
+      - name: Commit prebuilt manifest
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add nix/prebuilt.json
+          git diff --cached --quiet && exit 0
+          git commit -m "release: update prebuilt manifest for v${{ needs.detect-version.outputs.version }}"
+          git push origin main

--- a/.github/workflows/nix_release.yml
+++ b/.github/workflows/nix_release.yml
@@ -1,0 +1,104 @@
+name: Nix Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  detect-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      skip: ${{ steps.detect.outputs.skip }}
+      notes: ${{ steps.detect.outputs.notes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect version from CHANGELOG.md
+        id: detect
+        run: |
+          # Extract latest non-Unreleased version header
+          version=$(grep -m1 -oP '(?<=^## \[)[0-9]+\.[0-9]+\.[0-9]+(?=\])' CHANGELOG.md || true)
+          if [ -z "$version" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No version found in CHANGELOG.md"
+            exit 0
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # Check if tag already exists
+          if git tag -l "v$version" | grep -q .; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Tag v$version already exists, skipping release"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          # Extract release notes for this version
+          notes=$(awk "/^## \[$version\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          {
+            echo "notes<<CHANGELOG_EOF"
+            echo "$notes"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: [detect-version]
+    if: needs.detect-version.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      GITHUB_TOKEN: ""
+      ACTIONS_RUNTIME_TOKEN: ""
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Nix store cache
+        uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Build weezterm (nix)
+        run: nix build ./nix -o result-nix
+      - name: Package nix build
+        run: |
+          VERSION="v${{ needs.detect-version.outputs.version }}"
+          mkdir -p release
+
+          # Package the full nix output (bin + terminfo + shell completions + icons)
+          tar czf "release/weezterm-${VERSION}-x86_64-linux-nix.tar.gz" \
+            -C result-nix .
+
+          cd release && sha256sum *.tar.gz > SHA256SUMS
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: release/
+
+  release:
+    needs: [detect-version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-binaries
+          path: release/
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="v${{ needs.detect-version.outputs.version }}"
+          NOTES="${{ needs.detect-version.outputs.notes }}"
+
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+          gh release create "$VERSION" release/* \
+            --title "$VERSION" \
+            --notes "$NOTES"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,18 +523,35 @@ Also disabled: `nix_continuous.yml`, `nix-update-flake.yml`, `pages.yml`,
 
 > Decision record: [ADR 0005 — Unified SemVer versioning](docs/adr/0005-unified-semver-versioning.md).
 
-1. Bump `version` in `wezterm-version/Cargo.toml` (e.g., `0.2.0` → `0.3.0`)
-2. Commit: `git commit -am "chore: bump version to 0.3.0"`
-3. Tag: `git tag -a v0.3.0 -m "WeezTerm v0.3.0"  &&  git push origin v0.3.0`
-4. The `weezterm-build` workflow triggers on `v*` tags
-5. Writes `.tag` file with the version (e.g., `0.3.0`)
-6. Builds all platforms, runs tests, packages artifacts
-7. `release` job creates a GitHub Release titled `WeezTerm v0.3.0`
+Releases are **changelog-driven**. Merging to `main` with a new version
+header in `CHANGELOG.md` triggers an automatic release.
+
+**Workflow:**
+
+1. During development, add entries under `## [Unreleased]` in `CHANGELOG.md`
+2. When ready to release:
+   - Bump `version` in `wezterm-version/Cargo.toml`
+   - Rename `## [Unreleased]` entries to `## [X.Y.Z] - YYYY-MM-DD`
+   - Add a fresh empty `## [Unreleased]` section above
+3. Merge PR to `main`
+4. The `nix_release.yml` workflow detects the new version, auto-tags `vX.Y.Z`,
+   builds the Nix package, and publishes a GitHub Release with binaries
+
+**The CI changelog gate requires:**
+- Every PR that changes code must update CHANGELOG.md
+- Format must follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+- Version headers: `## [X.Y.Z] - YYYY-MM-DD` (valid semver + ISO date)
 
 **Version format:**
-- Release builds: `0.3.0` (from `.tag` file)
-- Dev builds: `0.3.0-dev.YYYYMMDD.SHORTHASH` (auto-derived from git)
-- The single source of truth is `wezterm-version/Cargo.toml`
+- Release builds: `0.4.0` (from CHANGELOG.md + Cargo.toml)
+- Dev builds: `0.4.0-dev.YYYYMMDD.SHORTHASH` (auto-derived from git)
+- Single source of truth: `CHANGELOG.md` (determines when a release is cut);
+  `wezterm-version/Cargo.toml` provides the in-binary version string
+
+**Nix release assets (x86_64-linux):**
+- `weezterm-vX.Y.Z-x86_64-linux-nix.tar.gz` — full `nix build` output
+  (binaries + terminfo + shell completions + desktop entry)
+- `SHA256SUMS`
 
 ### Branch protection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to WeezTerm are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2026-04-07
+
+### Added
+
+- Auto-install weezterm binaries on remote hosts for SSH multiplexing
+- `remote_install_binaries_dir` config for cross-platform dev (Windows → Linux)
+- `ci/build-cross.sh` for building Windows + Linux via WSL
+- Mux-only tarballs in CI releases for lightweight remote deployment
+
+### Fixed
+
+- Fix tilde expansion in remote path commands
+- Replace SFTP upload with reliable SSH exec+stdin
+- Resolve merge conflict markers in CI workflow
+
+## [0.3.0] - 2026-04-06
+
+### Changed
+
+- Rebrand from WezTerm to WeezTerm (casing, GitHub URLs, desktop entries)
+- Nix flake outputs use `weezterm` binary name exclusively
+
+### Fixed
+
+- Dependency bumps (time, rustls-webpki, bytes, tar)

--- a/nix/prebuilt.json
+++ b/nix/prebuilt.json
@@ -1,0 +1,5 @@
+{
+  "version": null,
+  "system": "x86_64-linux",
+  "binaries": {}
+}

--- a/scripts/changelog-check.sh
+++ b/scripts/changelog-check.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Validate CHANGELOG.md format (Keep a Changelog + semver).
+# Exit 0 if valid, non-zero with diagnostics otherwise.
+set -euo pipefail
+
+CHANGELOG="${1:-CHANGELOG.md}"
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "ERROR: $CHANGELOG not found"
+  exit 1
+fi
+
+errors=0
+
+# Check [Unreleased] section exists
+if ! grep -q '^\## \[Unreleased\]' "$CHANGELOG"; then
+  echo "ERROR: Missing '## [Unreleased]' section"
+  errors=$((errors + 1))
+fi
+
+# Extract version headers (excluding Unreleased)
+versions=$(grep -oP '(?<=^## \[)[0-9]+\.[0-9]+\.[0-9]+(?=\] - )' "$CHANGELOG" || true)
+
+if [ -z "$versions" ]; then
+  echo "WARN: No released versions found in changelog (only [Unreleased])"
+  exit $errors
+fi
+
+# Check format of each version line
+while IFS= read -r line; do
+  if echo "$line" | grep -qP '^\## \['; then
+    # Skip [Unreleased]
+    if echo "$line" | grep -q '^\## \[Unreleased\]'; then
+      continue
+    fi
+    # Must match ## [X.Y.Z] - YYYY-MM-DD
+    if ! echo "$line" | grep -qP '^\## \[\d+\.\d+\.\d+\] - \d{4}-\d{2}-\d{2}$'; then
+      echo "ERROR: Malformed version header: $line"
+      echo "  Expected format: ## [X.Y.Z] - YYYY-MM-DD"
+      errors=$((errors + 1))
+    fi
+  fi
+done < "$CHANGELOG"
+
+# Check for duplicate versions
+dupes=$(echo "$versions" | sort | uniq -d)
+if [ -n "$dupes" ]; then
+  echo "ERROR: Duplicate version(s): $dupes"
+  errors=$((errors + 1))
+fi
+
+# Check descending order (latest first)
+sorted=$(echo "$versions" | sort -rV)
+if [ "$versions" != "$sorted" ]; then
+  echo "ERROR: Versions are not in descending order"
+  echo "  Found:    $(echo "$versions" | tr '\n' ' ')"
+  echo "  Expected: $(echo "$sorted" | tr '\n' ' ')"
+  errors=$((errors + 1))
+fi
+
+# Validate dates are real ISO 8601 dates
+while IFS= read -r line; do
+  if echo "$line" | grep -qP '^\## \[\d'; then
+    date_str=$(echo "$line" | grep -oP '\d{4}-\d{2}-\d{2}' || true)
+    if [ -n "$date_str" ]; then
+      if ! date -d "$date_str" >/dev/null 2>&1; then
+        echo "ERROR: Invalid date '$date_str' in: $line"
+        errors=$((errors + 1))
+      fi
+    fi
+  fi
+done < "$CHANGELOG"
+
+if [ $errors -gt 0 ]; then
+  echo "FAILED: $errors error(s) found in $CHANGELOG"
+  exit 1
+fi
+
+echo "OK: $CHANGELOG format is valid ($(echo "$versions" | wc -l) released version(s))"


### PR DESCRIPTION
## Summary

Add changelog-driven auto-release for Nix-built binaries + changelog validation CI gate.

### Changes

- **`nix_release.yml`**: On push to main, detects new version in CHANGELOG.md, auto-tags, builds via `nix build`, publishes GitHub Release with tarball + SHA256SUMS
- **`changelog-check.yml`**: PR gate ensuring CHANGELOG.md is updated and properly formatted
- **`scripts/changelog-check.sh`**: Validation script (semver, ISO dates, no dupes, descending order)
- **`CHANGELOG.md`**: Created with retroactive entries for v0.3.0 and v0.4.0
- **AGENTS.md**: Updated release process documentation

### Security

Build job has zero token access (`GITHUB_TOKEN` and `ACTIONS_RUNTIME_TOKEN` explicitly unset). Only the release job has `contents: write`.