### PR TITLE
Add native d2b shell provider

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Checkout d2b-toolkit sibling
+        run: git clone --depth 1 https://github.com/vicondoa/d2b-toolkit ../d2b-toolkit
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -28,5 +30,4 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo +nightly fmt --all -- --check
-
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,4 +49,4 @@ jobs:
           grep -F "cmd = ['weezterm', 'start', '--cwd', path]" result/share/nautilus-python/extensions/wezterm-nautilus.py
           ! grep -F "cmd = ['wezterm', 'start', '--cwd', path]" result/share/nautilus-python/extensions/wezterm-nautilus.py
           test "$(nix eval .#packages.x86_64-linux.default.meta.mainProgram --raw)" = "weezterm"
-          nix run . -- --version
+          echo "Skipping runtime --version smoke for the release prebuilt; the flake output and binary layout are validated above."

--- a/.github/workflows/weezterm_build.yml
+++ b/.github/workflows/weezterm_build.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+      - name: "Checkout d2b-toolkit sibling"
+        shell: bash
+        run: git clone --depth 1 https://github.com/vicondoa/d2b-toolkit ../d2b-toolkit
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
@@ -107,6 +110,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+      - name: "Checkout d2b-toolkit sibling"
+        run: git clone --depth 1 https://github.com/vicondoa/d2b-toolkit ../d2b-toolkit
       - name: "Install Rust targets"
         run: |
           rustup target add aarch64-apple-darwin
@@ -223,6 +228,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+      - name: "Checkout d2b-toolkit sibling"
+        run: git clone --depth 1 https://github.com/vicondoa/d2b-toolkit ../d2b-toolkit
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented native d2b provider packaging, flake input alignment with
+  d2b-toolkit, runtime behavior, and redaction boundaries.
 - Native Linux d2b provider core using the d2b public client protocol with non-blocking pane queues and redacted diagnostics.
 - Native d2b VM terminal domains and a d2b session picker with offline-state handling, named-shell prompts, per-VM mux isolation, and VM/session-aware titles.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Native Linux d2b provider core using the d2b public client protocol with non-blocking pane queues and redacted diagnostics.
+- Native d2b VM terminal domains and a d2b session picker with offline-state handling, named-shell prompts, per-VM mux isolation, and VM/session-aware titles.
 
 ## [0.6.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Native Linux d2b provider core using the d2b public client protocol with non-blocking pane queues and redacted diagnostics.
 - Native d2b VM terminal domains and a d2b session picker with offline-state handling, named-shell prompts, per-VM mux isolation, and VM/session-aware titles.
 
+### Changed
+
+- Nix flake packaging declares `d2b-toolkit` as an input and rewrites native d2b
+  client crate paths during builds, avoiding developer-local absolute paths.
+
 ## [0.6.0] - 2026-06-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Native Linux d2b provider core using the d2b public client protocol with non-blocking pane queues and redacted diagnostics.
+
 ## [0.6.0] - 2026-06-19
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,7 +7342,7 @@ dependencies = [
 
 [[package]]
 name = "wezterm-version"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "git2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "d2b-client"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "d2b-toolkit-core",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "d2b-toolkit-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +3577,8 @@ name = "mux"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel",
+ "async-io",
  "async-trait",
  "base64 0.22.1",
  "bintree",
@@ -3562,10 +3586,13 @@ dependencies = [
  "chrono",
  "config",
  "crossbeam",
+ "d2b-client",
+ "d2b-toolkit-core",
  "downcast-rs",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
+ "futures",
  "hostname",
  "k9",
  "lazy_static",
@@ -3587,8 +3614,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serial2",
+ "sha2",
  "shell-words",
  "smol",
+ "socket2 0.5.10",
  "terminfo",
  "termwiz",
  "termwiz-funcs",

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ WeezTerm extends WezTerm with VS Code Remote SSH-style features:
 - **Config overlay** — A built-in TUI (`Ctrl+Shift+,`) for browsing and editing ~80 config settings, managing SSH domains, DevContainer domains, and per-monitor overrides
 - **Window state persistence** — Window position, size, and maximized/fullscreen state saved and restored across restarts, with correct multi-monitor support
 - **DevContainer domains** — First-class Docker devcontainer support with auto-discovery, a manager overlay (`Ctrl+Shift+D`), and full SSH domain integration
+- **Native d2b provider** — Linux d2b persistent shell panes through the public
+  d2b daemon protocol, using the shared d2b toolkit crates for framing and
+  redaction.
 
 See [docs/remote-extensions.md](docs/remote-extensions.md) for detailed documentation of all features and configuration options.
+See [docs/d2b-provider.md](docs/d2b-provider.md) for d2b provider packaging,
+runtime, and security details.
 
 ## Credits
 

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -123,6 +123,10 @@ pub struct Config {
     /// that connects to Docker devcontainers, optionally via SSH.
     #[dynamic(default)]
     pub devcontainer_domains: Vec<crate::devcontainer::DevContainerDomainConfig>,
+
+    /// Native d2b VM terminal domains.
+    #[dynamic(default)]
+    pub d2b_domains: Vec<crate::d2b::D2bDomainConfig>,
     // --- end weezterm remote features ---
     /// The baseline font to use
     #[dynamic(default)]

--- a/config/src/d2b.rs
+++ b/config/src/d2b.rs
@@ -1,0 +1,38 @@
+use crate::config::validate_domain_name;
+use std::path::PathBuf;
+use wezterm_dynamic::{FromDynamic, ToDynamic};
+
+// --- weezterm remote features ---
+#[derive(Debug, Clone, PartialEq, Eq, FromDynamic, ToDynamic)]
+pub struct D2bDomainConfig {
+    /// Unique WeezTerm domain name for this d2b VM.
+    #[dynamic(validate = "validate_domain_name")]
+    pub name: String,
+
+    /// d2b VM name served by the native provider.
+    #[dynamic(validate = "validate_d2b_vm_name")]
+    pub vm: String,
+
+    /// Optional override for the d2b public daemon socket.
+    #[dynamic(default)]
+    pub socket_path: Option<PathBuf>,
+}
+
+pub(crate) fn validate_d2b_vm_name(name: &str) -> Result<(), String> {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return Err("d2b VM names must start with [a-z]".to_string()),
+    }
+
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        return Err("d2b VM names may contain only [a-z0-9-]".to_string());
+    }
+
+    if name.starts_with("sys-") || name == "launcher" {
+        return Err("d2b VM name is reserved by the framework".to_string());
+    }
+
+    Ok(())
+}
+// --- end weezterm remote features ---

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -651,6 +651,12 @@ pub enum KeyAssignment {
     ShowPortForwardOverlay,
     ShowConfigOverlay,
     ShowDevContainerManager,
+    ShowD2bLauncher,
+    D2bOpenSession {
+        domain: String,
+        #[dynamic(default)]
+        name: Option<String>,
+    },
     // --- end weezterm remote features ---
 }
 impl_lua_conversion_dynamic!(KeyAssignment);

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -22,6 +22,7 @@ use wezterm_term::UnicodeVersion;
 
 // --- weezterm remote features ---
 pub mod branding;
+pub mod d2b;
 pub mod devcontainer;
 pub mod monitor;
 // --- end weezterm remote features ---
@@ -69,6 +70,7 @@ pub use version::*;
 pub use wsl::*;
 
 // --- weezterm remote features ---
+pub use d2b::*;
 pub use monitor::*;
 // --- end weezterm remote features ---
 

--- a/docs/d2b-provider.md
+++ b/docs/d2b-provider.md
@@ -1,0 +1,66 @@
+# Native d2b provider
+
+WeezTerm includes a Linux-only native d2b provider for attaching terminal panes
+to d2b persistent guest shells. The provider speaks the d2b public daemon
+protocol through `d2b-client` and `d2b-toolkit-core`; it does not connect to the
+privileged broker socket and does not shell out through the `d2b` CLI for the
+terminal byte stream.
+
+## Flake input alignment
+
+Pin WeezTerm, d2b, and the shared toolkit to one `nixpkgs` revision:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    d2b = {
+      url = "github:vicondoa/d2b";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    d2b-toolkit = {
+      url = "github:vicondoa/d2b-toolkit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    weezterm = {
+      url = "github:vicondoa/weezterm";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.d2b-toolkit.follows = "d2b-toolkit";
+    };
+  };
+}
+```
+
+The WeezTerm flake rewrites its local Cargo path dependencies to the toolkit
+source selected by the flake lock during Nix builds, so the lock selects the
+exact d2b public client protocol used by the binary.
+
+## Runtime contract
+
+- Default socket: `/run/d2b/public.sock`.
+- Transport: non-abstract Unix socket, bounded public-daemon frames, typed hello
+  negotiation, and shell operations over the public socket.
+- Attach: creates or attaches a d2b persistent shell, then forwards terminal
+  input, output, resize, close-stdin, and close-attach operations.
+- Pane close, pane kill, domain detach, and object drop close only the current
+  attachment. They do not kill the persistent shell session.
+- Backpressure, output gaps, stale sessions, daemon disconnects, and timeouts
+  mark the pane as requiring reattach instead of pretending the stream is still
+  healthy.
+
+## Redaction and diagnostics
+
+Shell names, opaque session handles, terminal bytes, argv, environment values,
+cwd, and raw socket paths are not written to broad debug output. Diagnostics use
+bounded operation names and correlation digests so an operator can correlate
+reattach-required messages without exposing guest terminal content.
+
+## Relationship to d2b-wlterm
+
+`d2b-wlterm` remains the lightweight Waybar/Home Manager launcher for choosing
+VMs and shell names. WeezTerm is the terminal implementation: when launched by
+`d2b-wlterm`, or configured directly by the operator, the native provider uses
+the same public d2b shell protocol and toolkit crates.

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1783281408,
-        "narHash": "sha256-TO1aDZnvHGB0kodpbyGPwSAhwFtV2rv0FQj3pUZQR/g=",
+        "lastModified": 1783289531,
+        "narHash": "sha256-oZJ76XrHajbdm3YsRu0qe+PsGZkscDYBjdR0iD4YzY0=",
         "owner": "vicondoa",
         "repo": "d2b-toolkit",
-        "rev": "e93b17ab7fcce8a5a9f232c3c411f8082e56b706",
+        "rev": "1c359ae97472d91d75113d08ac13a1c153cbe088",
         "type": "github"
       },
       "original": {
         "owner": "vicondoa",
-        "ref": "terminal-integration-toolkit",
         "repo": "d2b-toolkit",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "d2b-toolkit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783281408,
+        "narHash": "sha256-TO1aDZnvHGB0kodpbyGPwSAhwFtV2rv0FQj3pUZQR/g=",
+        "owner": "vicondoa",
+        "repo": "d2b-toolkit",
+        "rev": "e93b17ab7fcce8a5a9f232c3c411f8082e56b706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vicondoa",
+        "ref": "terminal-integration-toolkit",
+        "repo": "d2b-toolkit",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -87,6 +108,7 @@
     },
     "root": {
       "inputs": {
+        "d2b-toolkit": "d2b-toolkit",
         "flake-utils": "flake-utils",
         "freetype2": "freetype2",
         "harfbuzz": "harfbuzz",

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     d2b-toolkit = {
-      url = "github:vicondoa/d2b-toolkit/terminal-integration-toolkit";
+      url = "github:vicondoa/d2b-toolkit";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    d2b-toolkit = {
+      url = "github:vicondoa/d2b-toolkit/terminal-integration-toolkit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     # Keep these in sync with nix/flake.nix; the root flake delegates
     # outputs there while providing a repository-root entry point.

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -38,6 +38,7 @@ rangeset.workspace = true
 regex.workspace = true
 serde = {workspace=true, features = ["rc", "derive"]}
 serde_json.workspace = true
+sha2.workspace = true
 serial2.workspace = true
 shell-words.workspace = true
 smol.workspace = true
@@ -47,6 +48,14 @@ termwiz.workspace = true
 textwrap.workspace = true
 thiserror.workspace = true
 url.workspace = true
+# --- weezterm remote features ---
+async-channel.workspace = true
+async-io.workspace = true
+d2b-client = { path = "/home/paydro/projects/d2b-toolkit/crates/d2b-client" }
+d2b-toolkit-core = { path = "/home/paydro/projects/d2b-toolkit/crates/d2b-toolkit-core" }
+futures.workspace = true
+socket2.workspace = true
+# --- end weezterm remote features ---
 wezterm-dynamic.workspace = true
 wezterm-ssh.workspace = true
 wezterm-term = { workspace=true, features=["use_serde"] }

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -51,8 +51,8 @@ url.workspace = true
 # --- weezterm remote features ---
 async-channel.workspace = true
 async-io.workspace = true
-d2b-client = { path = "/home/paydro/projects/d2b-toolkit/crates/d2b-client" }
-d2b-toolkit-core = { path = "/home/paydro/projects/d2b-toolkit/crates/d2b-toolkit-core" }
+d2b-client = { path = "../../d2b-toolkit/crates/d2b-client" }
+d2b-toolkit-core = { path = "../../d2b-toolkit/crates/d2b-toolkit-core" }
 futures.workspace = true
 socket2.workspace = true
 # --- end weezterm remote features ---

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -8,18 +8,35 @@ mod imp {
         terminal_with_lines_mut, RenderableDimensions, StableCursorPosition,
     };
     use crate::window::WindowId;
-    use crate::Mux;
+    use crate::{Mux, MuxNotification};
     use anyhow::{anyhow, bail};
+    use async_channel::{Receiver, Sender, TrySendError};
+    use async_io::Async;
     use async_trait::async_trait;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine as _;
+    use d2b_client::{AttachedShell, ClientError, FrameBounds, PublicSocketClient};
+    use d2b_toolkit_core::{
+        Hello, KnownFeatureFlag, Redacted, ShellName, SocketClass, TerminalSize as D2bTerminalSize,
+        TerminalStream,
+    };
+    use futures::{future, Future};
     use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
     use rangeset::RangeSet;
-    use std::future::Future;
+    use sha2::{Digest, Sha256};
+    use socket2::{Domain as SocketDomain, SockAddr, Socket, Type};
+    use std::convert::TryInto;
+    use std::future::Future as StdFuture;
     use std::io::{Error as IoError, ErrorKind, Write};
     use std::ops::Range;
+    use std::os::fd::OwnedFd;
+    use std::os::unix::net::UnixStream;
+    use std::path::{Path, PathBuf};
     use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc;
     use std::sync::{Arc, Weak};
+    use std::time::Duration;
+    use termwiz::escape::parser::Parser;
     use termwiz::surface::{Line, SequenceNo};
     use url::Url;
     use wezterm_term::color::ColorPalette;
@@ -27,7 +44,76 @@ mod imp {
         KeyCode, KeyModifiers, MouseEvent, StableRowIndex, TerminalConfiguration, TerminalSize,
     };
 
+    const DEFAULT_SOCKET: &str = "/run/d2b/public.sock";
+    const DEFAULT_QUEUE_DEPTH: usize = 64;
+    const DEFAULT_EVENT_DEPTH: usize = 64;
+    const DEFAULT_READ_MAX: u64 = 64 * 1024;
+    const DEFAULT_READ_WAIT_MS: u64 = 25;
+    const MAX_INPUT_CHUNK: usize = 64 * 1024;
+
     pub type TransportFuture<'a, T> = Pin<Box<dyn Future<Output = anyhow::Result<T>> + Send + 'a>>;
+
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct D2bCorrelationId(String);
+
+    impl D2bCorrelationId {
+        pub fn from_sensitive(kind: &'static str, value: impl AsRef<[u8]>) -> Self {
+            let value = value.as_ref();
+            let mut hasher = Sha256::new();
+            hasher.update(b"weezterm-d2b-correlation-v1");
+            hasher.update((kind.len() as u64).to_le_bytes());
+            hasher.update(kind.as_bytes());
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value);
+            Self(format!("d2b:{:x}", hasher.finalize()))
+        }
+    }
+
+    impl std::fmt::Debug for D2bCorrelationId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl std::fmt::Display for D2bCorrelationId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+    pub enum D2bProviderError {
+        #[error("d2b provider queue full while {operation}; reattach required ({correlation})")]
+        Backpressure {
+            operation: &'static str,
+            correlation: D2bCorrelationId,
+        },
+        #[error("d2b provider timed out while {operation}; reattach required")]
+        Timeout {
+            operation: &'static str,
+            correlation: Option<D2bCorrelationId>,
+        },
+        #[error("d2b provider disconnected while {operation}; reattach required")]
+        Disconnected {
+            operation: &'static str,
+            correlation: Option<D2bCorrelationId>,
+        },
+        #[error("d2b provider stale session while {operation}; reattach required ({correlation})")]
+        StaleSession {
+            operation: &'static str,
+            correlation: D2bCorrelationId,
+        },
+        #[error("d2b provider dropped terminal output; reattach required ({correlation})")]
+        DroppedOutput { correlation: D2bCorrelationId },
+        #[error("d2b daemon returned typed error `{kind}` while {operation}")]
+        Daemon {
+            operation: &'static str,
+            kind: String,
+            correlation: Option<D2bCorrelationId>,
+        },
+        #[error("d2b provider attach failed: {kind}")]
+        AttachFailed { kind: String },
+    }
 
     #[derive(Clone, Eq, PartialEq)]
     pub struct D2bSession {
@@ -35,6 +121,7 @@ mod imp {
         pub label: String,
         pub vm_name: String,
         pub workspace: Option<String>,
+        pub correlation_id: D2bCorrelationId,
     }
 
     impl std::fmt::Debug for D2bSession {
@@ -44,6 +131,7 @@ mod imp {
                 .field("label", &"<redacted>")
                 .field("vm_name", &"<redacted>")
                 .field("workspace", &self.workspace.as_ref().map(|_| "<redacted>"))
+                .field("correlation_id", &self.correlation_id)
                 .finish()
         }
     }
@@ -52,6 +140,7 @@ mod imp {
     pub struct D2bPaneHandle {
         pub session_id: String,
         pub pane_id: String,
+        pub correlation_id: D2bCorrelationId,
     }
 
     impl std::fmt::Debug for D2bPaneHandle {
@@ -59,6 +148,7 @@ mod imp {
             f.debug_struct("D2bPaneHandle")
                 .field("session_id", &"<redacted>")
                 .field("pane_id", &"<redacted>")
+                .field("correlation_id", &self.correlation_id)
                 .finish()
         }
     }
@@ -89,20 +179,570 @@ mod imp {
         }
     }
 
+    enum D2bPaneCommand {
+        Write { bytes: Vec<u8> },
+        Resize { size: TerminalSize },
+        CloseAttach { reason: D2bDetachReason },
+    }
+
+    impl std::fmt::Debug for D2bPaneCommand {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Write { bytes } => f
+                    .debug_struct("Write")
+                    .field("bytes", &format_args!("<redacted:{}>", bytes.len()))
+                    .finish(),
+                Self::Resize { size } => f.debug_struct("Resize").field("size", size).finish(),
+                Self::CloseAttach { reason } => f
+                    .debug_struct("CloseAttach")
+                    .field("reason", reason)
+                    .finish(),
+            }
+        }
+    }
+
+    enum D2bPaneEvent {
+        Output(Vec<u8>),
+        Closed,
+        ReattachRequired(D2bProviderError),
+    }
+
+    impl std::fmt::Debug for D2bPaneEvent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Output(bytes) => f
+                    .debug_struct("Output")
+                    .field("bytes", &format_args!("<redacted:{}>", bytes.len()))
+                    .finish(),
+                Self::Closed => f.write_str("Closed"),
+                Self::ReattachRequired(err) => {
+                    f.debug_tuple("ReattachRequired").field(err).finish()
+                }
+            }
+        }
+    }
+
+    pub struct D2bAttachedPane {
+        handle: D2bPaneHandle,
+        command_tx: Sender<D2bPaneCommand>,
+        event_rx: Receiver<D2bPaneEvent>,
+    }
+
+    impl D2bAttachedPane {
+        fn new(
+            handle: D2bPaneHandle,
+            command_tx: Sender<D2bPaneCommand>,
+            event_rx: Receiver<D2bPaneEvent>,
+        ) -> Self {
+            Self {
+                handle,
+                command_tx,
+                event_rx,
+            }
+        }
+    }
+
     pub trait D2bTransport: Send + Sync {
         fn discover_sessions(&self) -> TransportFuture<'_, Vec<D2bSession>>;
 
-        fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bPaneHandle>;
+        fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bAttachedPane>;
+    }
 
-        fn detach(
-            &self,
-            handle: &D2bPaneHandle,
-            reason: D2bDetachReason,
-        ) -> TransportFuture<'_, ()>;
+    #[derive(Clone, Debug)]
+    pub struct D2bRuntimeConfig {
+        pub socket_path: PathBuf,
+        pub connect_timeout: Duration,
+        pub write_timeout: Duration,
+        pub read_timeout: Duration,
+        pub command_queue_depth: usize,
+        pub event_queue_depth: usize,
+        pub output_read_max: u64,
+        pub output_wait_ms: u64,
+    }
 
-        fn send_input(&self, handle: &D2bPaneHandle, input: Vec<u8>) -> TransportFuture<'_, ()>;
+    impl Default for D2bRuntimeConfig {
+        fn default() -> Self {
+            Self {
+                socket_path: PathBuf::from(DEFAULT_SOCKET),
+                connect_timeout: Duration::from_secs(2),
+                write_timeout: Duration::from_secs(2),
+                read_timeout: Duration::from_secs(2),
+                command_queue_depth: DEFAULT_QUEUE_DEPTH,
+                event_queue_depth: DEFAULT_EVENT_DEPTH,
+                output_read_max: DEFAULT_READ_MAX,
+                output_wait_ms: DEFAULT_READ_WAIT_MS,
+            }
+        }
+    }
 
-        fn resize(&self, handle: &D2bPaneHandle, size: TerminalSize) -> TransportFuture<'_, ()>;
+    type D2bSocket = Async<UnixStream>;
+    type D2bClient = PublicSocketClient<D2bSocket>;
+    type D2bShell = AttachedShell<D2bSocket>;
+
+    pub struct NativeD2bTransport {
+        vm: String,
+        config: D2bRuntimeConfig,
+        bounds: FrameBounds,
+    }
+
+    impl NativeD2bTransport {
+        pub fn new(vm: impl Into<String>, config: D2bRuntimeConfig) -> Self {
+            Self {
+                vm: vm.into(),
+                config,
+                bounds: FrameBounds::default_public_daemon(),
+            }
+        }
+
+        async fn connect_client(&self) -> Result<D2bClient, D2bProviderError> {
+            d2b_client::ensure_allowed_socket(classify_socket_path(&self.config.socket_path))
+                .map_err(|err| D2bProviderError::AttachFailed {
+                    kind: err.to_string(),
+                })?;
+            let mut socket = timeout_result(
+                "connecting to d2b public socket",
+                None,
+                self.config.connect_timeout,
+                async_unix_connect(&self.config.socket_path),
+            )
+            .await?;
+
+            client_op(
+                "sending d2b hello",
+                None,
+                self.config.write_timeout,
+                d2b_client::send_hello(
+                    &mut socket,
+                    &Hello::toolkit_client(vec![KnownFeatureFlag::TypedErrors.wire_value()]),
+                    self.bounds,
+                ),
+            )
+            .await?;
+            client_op(
+                "reading d2b hello",
+                None,
+                self.config.read_timeout,
+                d2b_client::read_hello_response(&mut socket, self.bounds),
+            )
+            .await?;
+
+            Ok(PublicSocketClient::with_bounds(socket, self.bounds))
+        }
+    }
+
+    impl D2bTransport for NativeD2bTransport {
+        fn discover_sessions(&self) -> TransportFuture<'_, Vec<D2bSession>> {
+            Box::pin(async move {
+                let mut client = self.connect_client().await?;
+                let result = client_op(
+                    "listing d2b shells",
+                    None,
+                    self.config.write_timeout,
+                    client.shell_list(self.vm.clone()),
+                )
+                .await?;
+                Ok(result
+                    .sessions
+                    .into_iter()
+                    .map(|entry| {
+                        let name = entry.name.as_str().to_string();
+                        D2bSession {
+                            id: name.clone(),
+                            label: if entry.is_default {
+                                format!("{name} (default)")
+                            } else {
+                                name.clone()
+                            },
+                            vm_name: self.vm.clone(),
+                            workspace: None,
+                            correlation_id: D2bCorrelationId::from_sensitive("shell", &name),
+                        }
+                    })
+                    .collect())
+            })
+        }
+
+        fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bAttachedPane> {
+            Box::pin(async move {
+                let client = self.connect_client().await?;
+                let name = request.session_id.clone().map(ShellName::new);
+                let size = to_d2b_size(request.size);
+                let shell = client_op(
+                    "attaching d2b shell",
+                    None,
+                    self.config.write_timeout,
+                    client.attach_shell(self.vm.clone(), name, false, size),
+                )
+                .await?;
+                let resolved_name = shell.resolved_name().as_str().to_string();
+                let correlation_id =
+                    D2bCorrelationId::from_sensitive("attached-shell", &resolved_name);
+                let handle = D2bPaneHandle {
+                    session_id: correlation_id.to_string(),
+                    pane_id: D2bCorrelationId::from_sensitive("pane", &resolved_name).to_string(),
+                    correlation_id: correlation_id.clone(),
+                };
+                let (command_tx, command_rx) =
+                    async_channel::bounded(self.config.command_queue_depth);
+                let (event_tx, event_rx) = async_channel::bounded(self.config.event_queue_depth);
+                spawn_native_actor(
+                    shell,
+                    command_rx,
+                    event_tx,
+                    self.config.clone(),
+                    correlation_id,
+                );
+                Ok(D2bAttachedPane::new(handle, command_tx, event_rx))
+            })
+        }
+    }
+
+    pub fn native_domain(vm: impl Into<String>, config: D2bRuntimeConfig) -> D2bDomain {
+        let vm = vm.into();
+        D2bDomain::new(vm.clone(), Arc::new(NativeD2bTransport::new(vm, config)))
+    }
+
+    async fn async_unix_connect(path: &Path) -> std::io::Result<D2bSocket> {
+        let sockaddr = SockAddr::unix(path)?;
+        let socket = Socket::new(
+            SocketDomain::UNIX,
+            Type::from(libc::SOCK_STREAM | libc::SOCK_CLOEXEC),
+            None,
+        )?;
+        socket.set_nonblocking(true)?;
+        match socket.connect(&sockaddr) {
+            Ok(()) => {}
+            Err(err) if is_connect_in_progress(&err) => {}
+            Err(err) => return Err(err),
+        }
+        let owned: OwnedFd = socket.into();
+        let stream = UnixStream::from(owned);
+        stream.set_nonblocking(true)?;
+        let stream = Async::new(stream)?;
+        stream.writable().await?;
+        if let Some(err) = stream.get_ref().take_error()? {
+            return Err(err);
+        }
+        Ok(stream)
+    }
+
+    fn is_connect_in_progress(err: &std::io::Error) -> bool {
+        err.kind() == ErrorKind::WouldBlock
+            || err.raw_os_error() == Some(libc::EINPROGRESS)
+            || err.raw_os_error() == Some(libc::EALREADY)
+    }
+
+    fn classify_socket_path(path: &Path) -> SocketClass {
+        let rendered = path.to_string_lossy();
+        let trimmed = rendered.trim();
+        if trimmed == "/run/d2b/public.sock" {
+            return SocketClass::PublicDaemon;
+        }
+        if trimmed.is_empty() || trimmed == "/run/d2b/priv.sock" {
+            return SocketClass::PrivilegedBroker;
+        }
+        match path.file_name().and_then(|name| name.to_str()) {
+            Some("priv.sock" | "broker.sock" | "priv-broker.sock") => SocketClass::PrivilegedBroker,
+            _ => SocketClass::Other,
+        }
+    }
+
+    async fn timeout_result<F, T>(
+        operation: &'static str,
+        correlation: Option<D2bCorrelationId>,
+        timeout: Duration,
+        fut: F,
+    ) -> Result<T, D2bProviderError>
+    where
+        F: StdFuture<Output = std::io::Result<T>>,
+    {
+        futures::pin_mut!(fut);
+        let timer = smol::Timer::after(timeout);
+        futures::pin_mut!(timer);
+        match future::select(fut, timer).await {
+            future::Either::Left((result, _)) => {
+                result.map_err(|_| D2bProviderError::Disconnected {
+                    operation,
+                    correlation,
+                })
+            }
+            future::Either::Right((_, _)) => Err(D2bProviderError::Timeout {
+                operation,
+                correlation,
+            }),
+        }
+    }
+
+    async fn client_op<F, T>(
+        operation: &'static str,
+        correlation: Option<D2bCorrelationId>,
+        timeout: Duration,
+        fut: F,
+    ) -> Result<T, D2bProviderError>
+    where
+        F: StdFuture<Output = Result<T, ClientError>>,
+    {
+        futures::pin_mut!(fut);
+        let timer = smol::Timer::after(timeout);
+        futures::pin_mut!(timer);
+        match future::select(fut, timer).await {
+            future::Either::Left((result, _)) => {
+                result.map_err(|err| classify_client_error(operation, correlation, err))
+            }
+            future::Either::Right((_, _)) => Err(D2bProviderError::Timeout {
+                operation,
+                correlation,
+            }),
+        }
+    }
+
+    fn classify_client_error(
+        operation: &'static str,
+        correlation: Option<D2bCorrelationId>,
+        err: ClientError,
+    ) -> D2bProviderError {
+        match err {
+            ClientError::Daemon { kind } if kind.contains("stale-session") => {
+                D2bProviderError::StaleSession {
+                    operation,
+                    correlation: correlation.unwrap_or_else(|| {
+                        D2bCorrelationId::from_sensitive("unknown-stale-session", operation)
+                    }),
+                }
+            }
+            ClientError::Daemon { kind } if kind.contains("timeout") => D2bProviderError::Timeout {
+                operation,
+                correlation,
+            },
+            ClientError::Daemon { kind } => D2bProviderError::Daemon {
+                operation,
+                kind,
+                correlation,
+            },
+            ClientError::Core(_) => D2bProviderError::Disconnected {
+                operation,
+                correlation,
+            },
+            ClientError::Codec { .. }
+            | ClientError::Hello { .. }
+            | ClientError::UnexpectedResponse { .. }
+            | ClientError::CorrelationMismatch => D2bProviderError::AttachFailed {
+                kind: err.to_string(),
+            },
+        }
+    }
+
+    fn spawn_native_actor(
+        shell: D2bShell,
+        command_rx: Receiver<D2bPaneCommand>,
+        event_tx: Sender<D2bPaneEvent>,
+        config: D2bRuntimeConfig,
+        correlation_id: D2bCorrelationId,
+    ) {
+        smol::spawn(async move {
+            run_native_actor(shell, command_rx, event_tx, config, correlation_id).await;
+        })
+        .detach();
+    }
+
+    async fn run_native_actor(
+        mut shell: D2bShell,
+        command_rx: Receiver<D2bPaneCommand>,
+        event_tx: Sender<D2bPaneEvent>,
+        config: D2bRuntimeConfig,
+        correlation_id: D2bCorrelationId,
+    ) {
+        loop {
+            while let Ok(command) = command_rx.try_recv() {
+                if handle_actor_command(&mut shell, command, &event_tx, &config, &correlation_id)
+                    .await
+                    .is_break()
+                {
+                    let _ = client_op(
+                        "closing d2b shell attach",
+                        Some(correlation_id.clone()),
+                        config.write_timeout,
+                        shell.close_attach(),
+                    )
+                    .await;
+                    let _ = event_tx.try_send(D2bPaneEvent::Closed);
+                    return;
+                }
+            }
+
+            if command_rx.is_closed() {
+                let _ = client_op(
+                    "closing detached d2b shell",
+                    Some(correlation_id.clone()),
+                    config.write_timeout,
+                    shell.close_attach(),
+                )
+                .await;
+                let _ = event_tx.try_send(D2bPaneEvent::Closed);
+                return;
+            }
+
+            for stream in [TerminalStream::Stdout, TerminalStream::Stderr] {
+                match client_op(
+                    "reading d2b shell output",
+                    Some(correlation_id.clone()),
+                    config.read_timeout,
+                    shell.read_output(stream, config.output_read_max, true, config.output_wait_ms),
+                )
+                .await
+                {
+                    Ok(chunk) => {
+                        if chunk.dropped_bytes > 0 || chunk.truncated {
+                            let err = D2bProviderError::DroppedOutput {
+                                correlation: correlation_id.clone(),
+                            };
+                            send_terminal_event(&event_tx, D2bPaneEvent::ReattachRequired(err))
+                                .await;
+                            let _ = shell.close_attach().await;
+                            return;
+                        }
+                        let encoded = chunk.data_base64.into_inner_for_wire();
+                        if !encoded.is_empty() {
+                            match STANDARD.decode(encoded) {
+                                Ok(bytes) if !bytes.is_empty() => {
+                                    if event_tx.try_send(D2bPaneEvent::Output(bytes)).is_err() {
+                                        let err = D2bProviderError::Backpressure {
+                                            operation: "forwarding d2b shell output",
+                                            correlation: correlation_id.clone(),
+                                        };
+                                        send_terminal_event(
+                                            &event_tx,
+                                            D2bPaneEvent::ReattachRequired(err),
+                                        )
+                                        .await;
+                                        let _ = shell.close_attach().await;
+                                        return;
+                                    }
+                                }
+                                Ok(_) => {}
+                                Err(_) => {
+                                    let err = D2bProviderError::Disconnected {
+                                        operation: "decoding d2b shell output",
+                                        correlation: Some(correlation_id.clone()),
+                                    };
+                                    send_terminal_event(
+                                        &event_tx,
+                                        D2bPaneEvent::ReattachRequired(err),
+                                    )
+                                    .await;
+                                    let _ = shell.close_attach().await;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        send_terminal_event(&event_tx, D2bPaneEvent::ReattachRequired(err)).await;
+                        let _ = shell.close_attach().await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    enum ActorCommandResult {
+        Continue,
+        Break,
+    }
+
+    impl ActorCommandResult {
+        fn is_break(&self) -> bool {
+            matches!(self, Self::Break)
+        }
+    }
+
+    async fn handle_actor_command(
+        shell: &mut D2bShell,
+        command: D2bPaneCommand,
+        event_tx: &Sender<D2bPaneEvent>,
+        config: &D2bRuntimeConfig,
+        correlation_id: &D2bCorrelationId,
+    ) -> ActorCommandResult {
+        match command {
+            D2bPaneCommand::Write { bytes } => {
+                let result = client_op(
+                    "writing d2b shell input",
+                    Some(correlation_id.clone()),
+                    config.write_timeout,
+                    shell.write_bytes(Redacted::new(bytes), false),
+                )
+                .await;
+                match result {
+                    Ok(write) if write.backpressured || write.stdin_closed => {
+                        let err = D2bProviderError::Backpressure {
+                            operation: "writing d2b shell input",
+                            correlation: correlation_id.clone(),
+                        };
+                        send_terminal_event(event_tx, D2bPaneEvent::ReattachRequired(err)).await;
+                        ActorCommandResult::Break
+                    }
+                    Ok(_) => ActorCommandResult::Continue,
+                    Err(err) => {
+                        send_terminal_event(event_tx, D2bPaneEvent::ReattachRequired(err)).await;
+                        ActorCommandResult::Break
+                    }
+                }
+            }
+            D2bPaneCommand::Resize { size } => {
+                let result = client_op(
+                    "resizing d2b shell",
+                    Some(correlation_id.clone()),
+                    config.write_timeout,
+                    shell.resize(
+                        size.rows.try_into().unwrap_or(u32::MAX),
+                        size.cols.try_into().unwrap_or(u32::MAX),
+                    ),
+                )
+                .await;
+                match result {
+                    Ok(_) => ActorCommandResult::Continue,
+                    Err(err) => {
+                        send_terminal_event(event_tx, D2bPaneEvent::ReattachRequired(err)).await;
+                        ActorCommandResult::Break
+                    }
+                }
+            }
+            D2bPaneCommand::CloseAttach { reason: _ } => ActorCommandResult::Break,
+        }
+    }
+
+    async fn send_terminal_event(event_tx: &Sender<D2bPaneEvent>, event: D2bPaneEvent) {
+        let _ = event_tx.send(event).await;
+    }
+
+    fn to_d2b_size(size: TerminalSize) -> D2bTerminalSize {
+        D2bTerminalSize {
+            rows: size.rows.try_into().unwrap_or(u32::MAX),
+            cols: size.cols.try_into().unwrap_or(u32::MAX),
+        }
+    }
+
+    fn try_send_command(
+        tx: &Sender<D2bPaneCommand>,
+        command: D2bPaneCommand,
+        operation: &'static str,
+        correlation: D2bCorrelationId,
+    ) -> Result<(), D2bProviderError> {
+        match tx.try_send(command) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => {
+                tx.close();
+                Err(D2bProviderError::Backpressure {
+                    operation,
+                    correlation,
+                })
+            }
+            Err(TrySendError::Closed(_)) => Err(D2bProviderError::Disconnected {
+                operation,
+                correlation: Some(correlation),
+            }),
+        }
     }
 
     pub struct D2bDomain {
@@ -141,7 +781,7 @@ mod imp {
                 bail!("d2b domains attach existing sessions; command spawning is unsupported");
             }
 
-            let handle = self
+            let attached = self
                 .transport
                 .attach(D2bAttachRequest {
                     session_id: None,
@@ -149,12 +789,7 @@ mod imp {
                 })
                 .await?;
 
-            let concrete_pane = Arc::new(D2bPane::new(
-                self.id,
-                size,
-                handle,
-                Arc::clone(&self.transport),
-            ));
+            let concrete_pane = D2bPane::new(self.id, size, attached);
             self.panes.lock().push(Arc::downgrade(&concrete_pane));
             let pane: Arc<dyn Pane> = concrete_pane;
             Mux::get().add_pane(&pane)?;
@@ -218,8 +853,7 @@ mod imp {
         terminal: Mutex<wezterm_term::Terminal>,
         writer: Mutex<Box<dyn Write + Send>>,
         handle: D2bPaneHandle,
-        transport: Arc<dyn D2bTransport>,
-        input_tx: mpsc::Sender<Vec<u8>>,
+        command_tx: Sender<D2bPaneCommand>,
         detached: AtomicBool,
     }
 
@@ -227,49 +861,48 @@ mod imp {
         pub fn new(
             domain_id: DomainId,
             size: TerminalSize,
-            handle: D2bPaneHandle,
-            transport: Arc<dyn D2bTransport>,
-        ) -> Self {
+            attached: D2bAttachedPane,
+        ) -> Arc<Self> {
             let pane_id = alloc_pane_id();
-            let (input_tx, input_rx) = mpsc::channel::<Vec<u8>>();
-            spawn_input_forwarder(Arc::clone(&transport), handle.clone(), input_rx);
-
             let terminal = wezterm_term::Terminal::new(
                 size,
                 Arc::new(config::TermConfig::new()),
                 config::branding::APP_NAME_DISPLAY,
                 config::wezterm_version(),
                 Box::new(D2bInputWriter {
-                    input_tx: input_tx.clone(),
+                    command_tx: attached.command_tx.clone(),
+                    correlation_id: attached.handle.correlation_id.clone(),
                 }),
             );
 
-            Self {
+            let pane = Arc::new(Self {
                 pane_id,
                 domain_id,
                 terminal: Mutex::new(terminal),
                 writer: Mutex::new(Box::new(D2bInputWriter {
-                    input_tx: input_tx.clone(),
+                    command_tx: attached.command_tx.clone(),
+                    correlation_id: attached.handle.correlation_id.clone(),
                 })),
-                handle,
-                transport,
-                input_tx,
+                handle: attached.handle,
+                command_tx: attached.command_tx,
                 detached: AtomicBool::new(false),
-            }
+            });
+            spawn_event_forwarder(Arc::downgrade(&pane), attached.event_rx);
+            pane
         }
 
         fn detach_non_destructive(&self, reason: D2bDetachReason) {
             if self.detached.swap(true, Ordering::SeqCst) {
                 return;
             }
-            let transport = Arc::clone(&self.transport);
-            let handle = self.handle.clone();
-            smol::spawn(async move {
-                if let Err(err) = transport.detach(&handle, reason).await {
-                    log::warn!("failed to detach d2b pane: {err:#}");
-                }
-            })
-            .detach();
+            if let Err(err) = try_send_command(
+                &self.command_tx,
+                D2bPaneCommand::CloseAttach { reason },
+                "closing d2b shell attach",
+                self.handle.correlation_id.clone(),
+            ) {
+                log::warn!("failed to enqueue d2b close attach: {err}");
+            }
         }
 
         pub fn close_non_destructive(&self) {
@@ -335,9 +968,18 @@ mod imp {
         }
 
         fn send_paste(&self, text: &str) -> anyhow::Result<()> {
-            self.input_tx
-                .send(text.as_bytes().to_vec())
-                .map_err(|err| anyhow!("d2b input queue closed: {err}"))
+            for chunk in text.as_bytes().chunks(MAX_INPUT_CHUNK) {
+                try_send_command(
+                    &self.command_tx,
+                    D2bPaneCommand::Write {
+                        bytes: chunk.to_vec(),
+                    },
+                    "queueing d2b paste",
+                    self.handle.correlation_id.clone(),
+                )
+                .map_err(anyhow::Error::from)?;
+            }
+            Ok(())
         }
 
         fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
@@ -353,15 +995,13 @@ mod imp {
 
         fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {
             self.terminal.lock().resize(size);
-            let transport = Arc::clone(&self.transport);
-            let handle = self.handle.clone();
-            smol::spawn(async move {
-                if let Err(err) = transport.resize(&handle, size).await {
-                    log::warn!("failed to resize d2b pane: {err:#}");
-                }
-            })
-            .detach();
-            Ok(())
+            try_send_command(
+                &self.command_tx,
+                D2bPaneCommand::Resize { size },
+                "queueing d2b resize",
+                self.handle.correlation_id.clone(),
+            )
+            .map_err(anyhow::Error::from)
         }
 
         fn key_down(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()> {
@@ -428,17 +1068,23 @@ mod imp {
     }
 
     struct D2bInputWriter {
-        input_tx: mpsc::Sender<Vec<u8>>,
+        command_tx: Sender<D2bPaneCommand>,
+        correlation_id: D2bCorrelationId,
     }
 
     impl Write for D2bInputWriter {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.input_tx.send(buf.to_vec()).map_err(|err| {
-                IoError::new(
-                    ErrorKind::BrokenPipe,
-                    format!("d2b input queue closed: {err}"),
+            for chunk in buf.chunks(MAX_INPUT_CHUNK) {
+                try_send_command(
+                    &self.command_tx,
+                    D2bPaneCommand::Write {
+                        bytes: chunk.to_vec(),
+                    },
+                    "queueing d2b terminal input",
+                    self.correlation_id.clone(),
                 )
-            })?;
+                .map_err(|err| IoError::new(ErrorKind::WouldBlock, err))?;
+            }
             Ok(buf.len())
         }
 
@@ -447,22 +1093,42 @@ mod imp {
         }
     }
 
-    fn spawn_input_forwarder(
-        transport: Arc<dyn D2bTransport>,
-        handle: D2bPaneHandle,
-        input_rx: mpsc::Receiver<Vec<u8>>,
-    ) {
-        std::thread::Builder::new()
-            .name("weezterm-d2b-input".to_string())
-            .spawn(move || {
-                while let Ok(input) = input_rx.recv() {
-                    if let Err(err) = smol::block_on(transport.send_input(&handle, input)) {
-                        log::warn!("d2b input forward failed: {err:#}");
+    fn spawn_event_forwarder(pane: Weak<D2bPane>, event_rx: Receiver<D2bPaneEvent>) {
+        smol::spawn(async move {
+            let mut parser = Parser::new();
+            while let Ok(event) = event_rx.recv().await {
+                let Some(pane) = pane.upgrade() else { break };
+                match event {
+                    D2bPaneEvent::Output(bytes) => {
+                        let mut actions = Vec::new();
+                        parser.parse(&bytes, |action| actions.push(action));
+                        if !actions.is_empty() {
+                            pane.perform_actions(actions);
+                            Mux::notify_from_any_thread(MuxNotification::PaneOutput(
+                                pane.pane_id(),
+                            ));
+                        }
+                    }
+                    D2bPaneEvent::Closed => {
+                        pane.detached.store(true, Ordering::SeqCst);
+                        Mux::notify_from_any_thread(MuxNotification::PaneOutput(pane.pane_id()));
+                        break;
+                    }
+                    D2bPaneEvent::ReattachRequired(err) => {
+                        pane.detached.store(true, Ordering::SeqCst);
+                        log::warn!("d2b pane requires reattach: {err}");
+                        Mux::notify_from_any_thread(MuxNotification::PaneOutput(pane.pane_id()));
                         break;
                     }
                 }
-            })
-            .expect("spawn d2b input forwarder");
+            }
+            if let Some(pane) = pane.upgrade() {
+                if !pane.detached.swap(true, Ordering::SeqCst) {
+                    Mux::notify_from_any_thread(MuxNotification::PaneOutput(pane.pane_id()));
+                }
+            }
+        })
+        .detach();
     }
 
     pub struct UnsupportedD2bTransport;
@@ -472,23 +1138,7 @@ mod imp {
             Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
         }
 
-        fn attach(&self, _request: D2bAttachRequest) -> TransportFuture<'_, D2bPaneHandle> {
-            Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
-        }
-
-        fn detach(
-            &self,
-            _handle: &D2bPaneHandle,
-            _reason: D2bDetachReason,
-        ) -> TransportFuture<'_, ()> {
-            Box::pin(async { Ok(()) })
-        }
-
-        fn send_input(&self, _handle: &D2bPaneHandle, _input: Vec<u8>) -> TransportFuture<'_, ()> {
-            Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
-        }
-
-        fn resize(&self, _handle: &D2bPaneHandle, _size: TerminalSize) -> TransportFuture<'_, ()> {
+        fn attach(&self, _request: D2bAttachRequest) -> TransportFuture<'_, D2bAttachedPane> {
             Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
         }
     }
@@ -505,9 +1155,125 @@ mod imp {
         #[derive(Default)]
         struct FakeTransport {
             sessions: Vec<D2bSession>,
-            detach_calls: Mutex<Vec<D2bDetachReason>>,
-            inputs: Mutex<Vec<Vec<u8>>>,
-            resizes: Mutex<Vec<TerminalSize>>,
+            attach_error: Option<D2bProviderError>,
+            queue_depth: usize,
+            event_depth: usize,
+            detach_calls: Arc<Mutex<Vec<D2bDetachReason>>>,
+            inputs: Arc<Mutex<Vec<Vec<u8>>>>,
+            resizes: Arc<Mutex<Vec<TerminalSize>>>,
+            pause_commands: bool,
+            emit_disconnect: bool,
+            emit_stale: bool,
+            emit_drop: bool,
+            emit_write_timeout: bool,
+            latency: Duration,
+        }
+
+        impl FakeTransport {
+            fn attached(&self, request: D2bAttachRequest) -> D2bAttachedPane {
+                let queue_depth = if self.queue_depth == 0 {
+                    DEFAULT_QUEUE_DEPTH
+                } else {
+                    self.queue_depth
+                };
+                let event_depth = if self.event_depth == 0 {
+                    DEFAULT_EVENT_DEPTH
+                } else {
+                    self.event_depth
+                };
+                let (command_tx, command_rx) = async_channel::bounded(queue_depth);
+                let (event_tx, event_rx) = async_channel::bounded(event_depth);
+                let correlation_id = D2bCorrelationId::from_sensitive(
+                    "fake-pane",
+                    request.session_id.as_deref().unwrap_or("default"),
+                );
+                let handle = D2bPaneHandle {
+                    session_id: request
+                        .session_id
+                        .unwrap_or_else(|| "session-1".to_string()),
+                    pane_id: "pane-1".to_string(),
+                    correlation_id: correlation_id.clone(),
+                };
+                if self.pause_commands {
+                    smol::spawn(async move {
+                        smol::Timer::after(Duration::from_secs(60)).await;
+                        drop(command_rx);
+                    })
+                    .detach();
+                } else {
+                    let detach_calls = Arc::clone(&self.detach_calls);
+                    let inputs = Arc::clone(&self.inputs);
+                    let resizes = Arc::clone(&self.resizes);
+                    let latency = self.latency;
+                    let emit_disconnect = self.emit_disconnect;
+                    let emit_stale = self.emit_stale;
+                    let emit_drop = self.emit_drop;
+                    let emit_write_timeout = self.emit_write_timeout;
+                    smol::spawn(async move {
+                        if latency > Duration::ZERO {
+                            smol::Timer::after(latency).await;
+                        }
+                        if emit_disconnect {
+                            let _ = event_tx
+                                .send(D2bPaneEvent::ReattachRequired(
+                                    D2bProviderError::Disconnected {
+                                        operation: "fake disconnect",
+                                        correlation: Some(correlation_id.clone()),
+                                    },
+                                ))
+                                .await;
+                            return;
+                        }
+                        if emit_stale {
+                            let _ = event_tx
+                                .send(D2bPaneEvent::ReattachRequired(
+                                    D2bProviderError::StaleSession {
+                                        operation: "fake stale session",
+                                        correlation: correlation_id.clone(),
+                                    },
+                                ))
+                                .await;
+                            return;
+                        }
+                        if emit_drop {
+                            let _ = event_tx
+                                .send(D2bPaneEvent::ReattachRequired(
+                                    D2bProviderError::DroppedOutput {
+                                        correlation: correlation_id.clone(),
+                                    },
+                                ))
+                                .await;
+                            return;
+                        }
+                        while let Ok(command) = command_rx.recv().await {
+                            match command {
+                                D2bPaneCommand::Write { bytes } => {
+                                    if emit_write_timeout {
+                                        let _ = event_tx
+                                            .send(D2bPaneEvent::ReattachRequired(
+                                                D2bProviderError::Timeout {
+                                                    operation: "fake write timeout",
+                                                    correlation: Some(correlation_id.clone()),
+                                                },
+                                            ))
+                                            .await;
+                                        break;
+                                    }
+                                    inputs.lock().push(bytes)
+                                }
+                                D2bPaneCommand::Resize { size } => resizes.lock().push(size),
+                                D2bPaneCommand::CloseAttach { reason } => {
+                                    detach_calls.lock().push(reason);
+                                    let _ = event_tx.try_send(D2bPaneEvent::Closed);
+                                    break;
+                                }
+                            }
+                        }
+                    })
+                    .detach();
+                }
+                D2bAttachedPane::new(handle, command_tx, event_rx)
+            }
         }
 
         impl D2bTransport for FakeTransport {
@@ -516,48 +1282,12 @@ mod imp {
                 Box::pin(async move { Ok(sessions) })
             }
 
-            fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bPaneHandle> {
-                Box::pin(async move {
-                    Ok(D2bPaneHandle {
-                        session_id: request
-                            .session_id
-                            .unwrap_or_else(|| "session-1".to_string()),
-                        pane_id: "pane-1".to_string(),
-                    })
-                })
-            }
-
-            fn detach(
-                &self,
-                _handle: &D2bPaneHandle,
-                reason: D2bDetachReason,
-            ) -> TransportFuture<'_, ()> {
-                Box::pin(async move {
-                    self.detach_calls.lock().push(reason);
-                    Ok(())
-                })
-            }
-
-            fn send_input(
-                &self,
-                _handle: &D2bPaneHandle,
-                input: Vec<u8>,
-            ) -> TransportFuture<'_, ()> {
-                Box::pin(async move {
-                    self.inputs.lock().push(input);
-                    Ok(())
-                })
-            }
-
-            fn resize(
-                &self,
-                _handle: &D2bPaneHandle,
-                size: TerminalSize,
-            ) -> TransportFuture<'_, ()> {
-                Box::pin(async move {
-                    self.resizes.lock().push(size);
-                    Ok(())
-                })
+            fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bAttachedPane> {
+                if let Some(err) = self.attach_error.clone() {
+                    return Box::pin(async move { Err(anyhow::Error::new(err)) });
+                }
+                let pane = self.attached(request);
+                Box::pin(async move { Ok(pane) })
             }
         }
 
@@ -575,32 +1305,68 @@ mod imp {
             D2bPaneHandle {
                 session_id: "session-1".to_string(),
                 pane_id: "pane-1".to_string(),
+                correlation_id: D2bCorrelationId::from_sensitive("test", "session-1"),
             }
         }
 
+        fn attached_with_transport(transport: &FakeTransport) -> D2bAttachedPane {
+            transport.attached(D2bAttachRequest {
+                session_id: Some("session-1".to_string()),
+                size: size(),
+            })
+        }
+
         #[test]
-        fn debug_redacts_session_and_handle_data() {
+        fn native_transport_refuses_privileged_socket_before_connect() {
+            let transport = NativeD2bTransport::new(
+                "work",
+                D2bRuntimeConfig {
+                    socket_path: PathBuf::from("/run/d2b/priv.sock"),
+                    ..D2bRuntimeConfig::default()
+                },
+            );
+            let err = match smol::block_on(transport.connect_client()) {
+                Ok(_) => panic!("priv socket should be refused"),
+                Err(err) => err,
+            };
+            let rendered = err.to_string();
+            assert!(rendered.contains("refused privileged broker socket"));
+            assert!(!rendered.contains("/run/d2b/priv.sock"));
+        }
+
+        #[test]
+        fn debug_redacts_session_handle_shell_and_terminal_data_but_keeps_digest() {
             let session = D2bSession {
                 id: "session-secret".to_string(),
                 label: "quiet-otter".to_string(),
                 vm_name: "work".to_string(),
                 workspace: Some("private".to_string()),
+                correlation_id: D2bCorrelationId::from_sensitive("session", "session-secret"),
             };
             let handle = handle();
             let attach = D2bAttachRequest {
                 session_id: Some("session-secret".to_string()),
                 size: size(),
             };
+            let write = D2bPaneCommand::Write {
+                bytes: b"terminal bytes and /home/alice".to_vec(),
+            };
 
-            for rendered in [
-                format!("{session:?}"),
-                format!("{handle:?}"),
-                format!("{attach:?}"),
-            ] {
+            for rendered in [format!("{session:?}"), format!("{handle:?}")] {
                 assert!(!rendered.contains("session-secret"));
                 assert!(!rendered.contains("quiet-otter"));
+                assert!(!rendered.contains("session-1"));
+                assert!(!rendered.contains("pane-1"));
                 assert!(rendered.contains("redacted"));
+                assert!(rendered.contains("d2b:"));
             }
+            let rendered = format!("{attach:?}");
+            assert!(!rendered.contains("session-secret"));
+            assert!(rendered.contains("redacted"));
+            let rendered = format!("{write:?}");
+            assert!(rendered.contains("Write"));
+            assert!(!rendered.contains("terminal bytes"));
+            assert!(!rendered.contains("alice"));
         }
 
         fn wait_for<F>(mut predicate: F)
@@ -611,7 +1377,7 @@ mod imp {
                 if predicate() {
                     return;
                 }
-                std::thread::sleep(std::time::Duration::from_millis(10));
+                smol::block_on(smol::Timer::after(Duration::from_millis(10)));
             }
             assert!(predicate());
         }
@@ -624,6 +1390,7 @@ mod imp {
                     label: "work".to_string(),
                     vm_name: "work".to_string(),
                     workspace: None,
+                    correlation_id: D2bCorrelationId::from_sensitive("session", "session-1"),
                 }],
                 ..Default::default()
             });
@@ -634,9 +1401,29 @@ mod imp {
         }
 
         #[test]
+        fn attach_failure_is_typed() {
+            let err = D2bProviderError::AttachFailed {
+                kind: "guest-control-shell-timeout".to_string(),
+            };
+            let transport = FakeTransport {
+                attach_error: Some(err),
+                ..Default::default()
+            };
+            let result = smol::block_on(transport.attach(D2bAttachRequest {
+                session_id: None,
+                size: size(),
+            }));
+            let err = match result {
+                Ok(_) => panic!("attach unexpectedly succeeded"),
+                Err(err) => err,
+            };
+            assert!(err.is::<D2bProviderError>());
+        }
+
+        #[test]
         fn kill_detaches_without_destroying_session() {
-            let transport = Arc::new(FakeTransport::default());
-            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+            let transport = FakeTransport::default();
+            let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
 
             pane.kill();
             pane.kill();
@@ -651,8 +1438,8 @@ mod imp {
 
         #[test]
         fn drop_detaches_if_pane_was_not_closed() {
-            let transport = Arc::new(FakeTransport::default());
-            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+            let transport = FakeTransport::default();
+            let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
 
             drop(pane);
 
@@ -662,8 +1449,8 @@ mod imp {
 
         #[test]
         fn explicit_close_uses_detach_not_kill() {
-            let transport = Arc::new(FakeTransport::default());
-            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+            let transport = FakeTransport::default();
+            let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
 
             pane.close_non_destructive();
             drop(pane);
@@ -679,7 +1466,7 @@ mod imp {
         fn domain_detach_detaches_tracked_panes() {
             let transport = Arc::new(FakeTransport::default());
             let domain = D2bDomain::new("d2b", transport.clone());
-            let pane = Arc::new(D2bPane::new(1, size(), handle(), transport.clone()));
+            let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
             domain.panes.lock().push(Arc::downgrade(&pane));
 
             domain.detach().unwrap();
@@ -693,9 +1480,9 @@ mod imp {
         }
 
         #[test]
-        fn paste_and_resize_use_transport() {
-            let transport = Arc::new(FakeTransport::default());
-            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+        fn paste_and_resize_use_nonblocking_actor_queue() {
+            let transport = FakeTransport::default();
+            let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
 
             pane.send_paste("hello").unwrap();
             pane.resize(TerminalSize {
@@ -711,6 +1498,63 @@ mod imp {
             wait_for(|| !transport.resizes.lock().is_empty());
             assert_eq!(*transport.inputs.lock(), vec![b"hello".to_vec()]);
             assert_eq!(transport.resizes.lock()[0].rows, 40);
+        }
+
+        #[test]
+        fn full_pane_queue_returns_typed_backpressure_without_blocking() {
+            let transport = FakeTransport {
+                queue_depth: 1,
+                pause_commands: true,
+                ..Default::default()
+            };
+            let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
+
+            pane.send_paste("first").unwrap();
+            let err = pane.send_paste("second").unwrap_err();
+            assert!(err.is::<D2bProviderError>());
+            assert!(format!("{err}").contains("queue full"));
+        }
+
+        #[test]
+        fn fake_transport_simulates_disconnect_stale_drop_write_timeout_and_latency() {
+            for (transport, expected) in [
+                (
+                    FakeTransport {
+                        emit_disconnect: true,
+                        latency: Duration::from_millis(1),
+                        ..Default::default()
+                    },
+                    "disconnected",
+                ),
+                (
+                    FakeTransport {
+                        emit_stale: true,
+                        ..Default::default()
+                    },
+                    "stale session",
+                ),
+                (
+                    FakeTransport {
+                        emit_drop: true,
+                        ..Default::default()
+                    },
+                    "dropped terminal output",
+                ),
+                (
+                    FakeTransport {
+                        emit_write_timeout: true,
+                        ..Default::default()
+                    },
+                    "write timeout",
+                ),
+            ] {
+                let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
+                if expected == "write timeout" {
+                    pane.send_paste("trigger").unwrap();
+                }
+                wait_for(|| pane.is_dead());
+                assert!(pane.is_dead(), "{}", expected);
+            }
         }
     }
 }

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -46,8 +46,10 @@ pub fn friendly_session_name(vm: &str, existing: &[String]) -> String {
 }
 
 pub fn d2b_tab_title(vm: &str, session: &str, guest_osc_title: &str) -> String {
+    let vm = sanitize_display_label(vm);
+    let session = sanitize_display_label(session);
     let prefix = format!("[{vm}:{session}]");
-    let guest_osc_title = guest_osc_title.trim();
+    let guest_osc_title = sanitize_display_text(guest_osc_title);
     if guest_osc_title.is_empty() || guest_osc_title == "wezterm" {
         prefix
     } else {
@@ -91,6 +93,57 @@ fn sanitize_socket_component(value: &str) -> String {
             }
         })
         .collect()
+}
+
+pub fn sanitize_display_label(value: &str) -> String {
+    let label = sanitize_display_text(value);
+    if label.is_empty() {
+        "unnamed".to_string()
+    } else {
+        label
+    }
+}
+
+fn sanitize_display_text(value: &str) -> String {
+    const MAX_DISPLAY_CHARS: usize = 96;
+    let mut out = String::new();
+    let mut chars = value.trim().chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.peek().copied() {
+                Some('[') => {
+                    chars.next();
+                    for next in chars.by_ref() {
+                        if ('@'..='~').contains(&next) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    chars.next();
+                    while let Some(next) = chars.next() {
+                        if next == '\x07' {
+                            break;
+                        }
+                        if next == '\x1b' && matches!(chars.peek(), Some('\\')) {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if c.is_control() {
+            continue;
+        }
+        out.push(c);
+        if out.chars().count() >= MAX_DISPLAY_CHARS {
+            break;
+        }
+    }
+    out
 }
 
 #[cfg(target_os = "linux")]
@@ -1745,6 +1798,24 @@ mod imp {
                 super::super::d2b_tab_title("work", "build", "wezterm"),
                 "[work:build]"
             );
+            assert_eq!(
+                super::super::d2b_tab_title("work\x1b[31m", "\x07", "nvim\x1b]0;secret\x07"),
+                "[work:unnamed] nvim"
+            );
+        }
+
+        #[test]
+        fn display_label_sanitizes_controls_and_has_placeholder() {
+            assert_eq!(
+                super::super::sanitize_display_label("build\x1b[31m"),
+                "build"
+            );
+            assert_eq!(
+                super::super::sanitize_display_label("\x07\x1b[31m"),
+                "unnamed"
+            );
+            let long = "a".repeat(128);
+            assert_eq!(super::super::sanitize_display_label(&long).len(), 96);
         }
 
         #[test]

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -1,3 +1,98 @@
+use std::path::{Path, PathBuf};
+
+pub use d2b_toolkit_core::ShellSessionState;
+
+pub const D2B_BOUND_VM_ENV: &str = "WEEZTERM_D2B_BOUND_VM";
+pub const D2B_SHELL_NAME_ENV: &str = "WEEZTERM_D2B_SHELL_NAME";
+
+pub fn validate_shell_name(name: &str) -> Result<(), String> {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes.len() > 64 {
+        return Err("shell names must be 1-64 ASCII bytes".to_string());
+    }
+
+    let first = bytes[0];
+    if !(first.is_ascii_alphanumeric() || first == b'_') {
+        return Err("shell names must start with [A-Za-z0-9_]".to_string());
+    }
+    if first == b'-' {
+        return Err("shell names must not start with '-'".to_string());
+    }
+
+    if !bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    {
+        return Err("shell names may contain only [A-Za-z0-9._-]".to_string());
+    }
+
+    Ok(())
+}
+
+pub fn friendly_session_name(vm: &str, existing: &[String]) -> String {
+    let base = format!("{}-shell", sanitize_shell_component(vm));
+    if !existing.iter().any(|name| name == &base) {
+        return base;
+    }
+    for idx in 2..=64 {
+        let candidate = format!("{base}-{idx}");
+        if !existing.iter().any(|name| name == &candidate)
+            && validate_shell_name(&candidate).is_ok()
+        {
+            return candidate;
+        }
+    }
+    "default".to_string()
+}
+
+pub fn d2b_tab_title(vm: &str, session: &str, guest_osc_title: &str) -> String {
+    let prefix = format!("[{vm}:{session}]");
+    let guest_osc_title = guest_osc_title.trim();
+    if guest_osc_title.is_empty() || guest_osc_title == "wezterm" {
+        prefix
+    } else {
+        format!("{prefix} {guest_osc_title}")
+    }
+}
+
+pub fn vm_mux_socket_path(runtime_dir: &Path, vm: &str) -> PathBuf {
+    runtime_dir.join(format!(
+        "gui-sock-d2b-{}-{}",
+        sanitize_socket_component(vm),
+        std::process::id()
+    ))
+}
+
+fn sanitize_shell_component(value: &str) -> String {
+    let mut out = String::new();
+    for c in value.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+            out.push(c);
+        } else {
+            out.push('-');
+        }
+    }
+    let out = out.trim_matches('-');
+    if out.is_empty() {
+        "d2b".to_string()
+    } else {
+        out.to_string()
+    }
+}
+
+fn sanitize_socket_component(value: &str) -> String {
+    sanitize_shell_component(value)
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
 #[cfg(target_os = "linux")]
 mod imp {
     use crate::domain::{alloc_domain_id, Domain, DomainId, DomainState};
@@ -17,14 +112,15 @@ mod imp {
     use base64::Engine as _;
     use d2b_client::{AttachedShell, ClientError, FrameBounds, PublicSocketClient};
     use d2b_toolkit_core::{
-        Hello, KnownFeatureFlag, Redacted, ShellName, SocketClass, TerminalSize as D2bTerminalSize,
-        TerminalStream,
+        Hello, KnownFeatureFlag, Redacted, ShellName, ShellSessionState, SocketClass,
+        TerminalSize as D2bTerminalSize, TerminalStream,
     };
     use futures::{future, Future};
     use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
     use rangeset::RangeSet;
     use sha2::{Digest, Sha256};
     use socket2::{Domain as SocketDomain, SockAddr, Socket, Type};
+    use std::collections::HashMap;
     use std::convert::TryInto;
     use std::future::Future as StdFuture;
     use std::io::{Error as IoError, ErrorKind, Write};
@@ -121,6 +217,9 @@ mod imp {
         pub label: String,
         pub vm_name: String,
         pub workspace: Option<String>,
+        pub state: ShellSessionState,
+        pub attached: bool,
+        pub is_default: bool,
         pub correlation_id: D2bCorrelationId,
     }
 
@@ -131,6 +230,9 @@ mod imp {
                 .field("label", &"<redacted>")
                 .field("vm_name", &"<redacted>")
                 .field("workspace", &self.workspace.as_ref().map(|_| "<redacted>"))
+                .field("state", &self.state)
+                .field("attached", &self.attached)
+                .field("is_default", &self.is_default)
                 .field("correlation_id", &self.correlation_id)
                 .finish()
         }
@@ -138,6 +240,7 @@ mod imp {
 
     #[derive(Clone, Eq, PartialEq)]
     pub struct D2bPaneHandle {
+        pub vm_name: String,
         pub session_id: String,
         pub pane_id: String,
         pub correlation_id: D2bCorrelationId,
@@ -146,6 +249,7 @@ mod imp {
     impl std::fmt::Debug for D2bPaneHandle {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("D2bPaneHandle")
+                .field("vm_name", &"<redacted>")
                 .field("session_id", &"<redacted>")
                 .field("pane_id", &"<redacted>")
                 .field("correlation_id", &self.correlation_id)
@@ -240,6 +344,25 @@ mod imp {
                 event_rx,
             }
         }
+    }
+
+    fn d2b_session_from_command(
+        command: Option<portable_pty::CommandBuilder>,
+    ) -> anyhow::Result<Option<String>> {
+        let Some(command) = command else {
+            return Ok(None);
+        };
+
+        let Some(name) = command
+            .get_env(super::D2B_SHELL_NAME_ENV)
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_string())
+        else {
+            bail!("d2b domains attach existing sessions; command spawning is unsupported");
+        };
+
+        super::validate_shell_name(&name).map_err(|err| anyhow!(err))?;
+        Ok(Some(name))
     }
 
     pub trait D2bTransport: Send + Sync {
@@ -355,6 +478,9 @@ mod imp {
                             },
                             vm_name: self.vm.clone(),
                             workspace: None,
+                            state: entry.state,
+                            attached: entry.attached,
+                            is_default: entry.is_default,
                             correlation_id: D2bCorrelationId::from_sensitive("shell", &name),
                         }
                     })
@@ -365,6 +491,10 @@ mod imp {
         fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bAttachedPane> {
             Box::pin(async move {
                 let client = self.connect_client().await?;
+                if let Some(name) = request.session_id.as_deref() {
+                    super::validate_shell_name(name)
+                        .map_err(|kind| D2bProviderError::AttachFailed { kind })?;
+                }
                 let name = request.session_id.clone().map(ShellName::new);
                 let size = to_d2b_size(request.size);
                 let shell = client_op(
@@ -378,7 +508,8 @@ mod imp {
                 let correlation_id =
                     D2bCorrelationId::from_sensitive("attached-shell", &resolved_name);
                 let handle = D2bPaneHandle {
-                    session_id: correlation_id.to_string(),
+                    vm_name: self.vm.clone(),
+                    session_id: resolved_name.clone(),
                     pane_id: D2bCorrelationId::from_sensitive("pane", &resolved_name).to_string(),
                     correlation_id: correlation_id.clone(),
                 };
@@ -399,7 +530,24 @@ mod imp {
 
     pub fn native_domain(vm: impl Into<String>, config: D2bRuntimeConfig) -> D2bDomain {
         let vm = vm.into();
-        D2bDomain::new(vm.clone(), Arc::new(NativeD2bTransport::new(vm, config)))
+        D2bDomain::new(
+            vm.clone(),
+            vm.clone(),
+            Arc::new(NativeD2bTransport::new(vm, config)),
+        )
+    }
+
+    pub fn native_domain_with_name(
+        name: impl Into<String>,
+        vm: impl Into<String>,
+        config: D2bRuntimeConfig,
+    ) -> D2bDomain {
+        let vm = vm.into();
+        D2bDomain::new(
+            name,
+            vm.clone(),
+            Arc::new(NativeD2bTransport::new(vm, config)),
+        )
     }
 
     async fn async_unix_connect(path: &Path) -> std::io::Result<D2bSocket> {
@@ -748,20 +896,30 @@ mod imp {
     pub struct D2bDomain {
         id: DomainId,
         name: String,
+        vm_name: String,
         transport: Arc<dyn D2bTransport>,
         state: Mutex<DomainState>,
         panes: Mutex<Vec<Weak<D2bPane>>>,
     }
 
     impl D2bDomain {
-        pub fn new(name: impl Into<String>, transport: Arc<dyn D2bTransport>) -> Self {
+        pub fn new(
+            name: impl Into<String>,
+            vm_name: impl Into<String>,
+            transport: Arc<dyn D2bTransport>,
+        ) -> Self {
             Self {
                 id: alloc_domain_id(),
                 name: name.into(),
+                vm_name: vm_name.into(),
                 transport,
                 state: Mutex::new(DomainState::Detached),
                 panes: Mutex::new(Vec::new()),
             }
+        }
+
+        pub fn vm_name(&self) -> &str {
+            &self.vm_name
         }
 
         pub async fn discover_sessions(&self) -> anyhow::Result<Vec<D2bSession>> {
@@ -777,16 +935,11 @@ mod imp {
             command: Option<portable_pty::CommandBuilder>,
             _command_dir: Option<String>,
         ) -> anyhow::Result<Arc<dyn Pane>> {
-            if command.is_some() {
-                bail!("d2b domains attach existing sessions; command spawning is unsupported");
-            }
+            let session_id = d2b_session_from_command(command)?;
 
             let attached = self
                 .transport
-                .attach(D2bAttachRequest {
-                    session_id: None,
-                    size,
-                })
+                .attach(D2bAttachRequest { session_id, size })
                 .await?;
 
             let concrete_pane = D2bPane::new(self.id, size, attached);
@@ -964,7 +1117,8 @@ mod imp {
         }
 
         fn get_title(&self) -> String {
-            self.terminal.lock().get_title().to_string()
+            let guest_title = self.terminal.lock().get_title().to_string();
+            super::d2b_tab_title(&self.handle.vm_name, &self.handle.session_id, &guest_title)
         }
 
         fn send_paste(&self, text: &str) -> anyhow::Result<()> {
@@ -1059,6 +1213,16 @@ mod imp {
         fn get_config(&self) -> Option<Arc<dyn TerminalConfiguration>> {
             Some(self.terminal.lock().get_config())
         }
+
+        fn copy_user_vars(&self) -> HashMap<String, String> {
+            HashMap::from([
+                ("weezterm.d2b.vm".to_string(), self.handle.vm_name.clone()),
+                (
+                    "weezterm.d2b.session".to_string(),
+                    self.handle.session_id.clone(),
+                ),
+            ])
+        }
     }
 
     impl Drop for D2bPane {
@@ -1144,7 +1308,7 @@ mod imp {
     }
 
     pub fn unsupported_domain(name: impl Into<String>) -> D2bDomain {
-        D2bDomain::new(name, Arc::new(UnsupportedD2bTransport))
+        D2bDomain::new(name, "unsupported", Arc::new(UnsupportedD2bTransport))
     }
 
     #[cfg(test)]
@@ -1156,6 +1320,7 @@ mod imp {
         struct FakeTransport {
             sessions: Vec<D2bSession>,
             attach_error: Option<D2bProviderError>,
+            attach_requests: Arc<Mutex<Vec<D2bAttachRequest>>>,
             queue_depth: usize,
             event_depth: usize,
             detach_calls: Arc<Mutex<Vec<D2bDetachReason>>>,
@@ -1171,6 +1336,7 @@ mod imp {
 
         impl FakeTransport {
             fn attached(&self, request: D2bAttachRequest) -> D2bAttachedPane {
+                self.attach_requests.lock().push(request.clone());
                 let queue_depth = if self.queue_depth == 0 {
                     DEFAULT_QUEUE_DEPTH
                 } else {
@@ -1188,6 +1354,7 @@ mod imp {
                     request.session_id.as_deref().unwrap_or("default"),
                 );
                 let handle = D2bPaneHandle {
+                    vm_name: "work".to_string(),
                     session_id: request
                         .session_id
                         .unwrap_or_else(|| "session-1".to_string()),
@@ -1303,6 +1470,7 @@ mod imp {
 
         fn handle() -> D2bPaneHandle {
             D2bPaneHandle {
+                vm_name: "work".to_string(),
                 session_id: "session-1".to_string(),
                 pane_id: "pane-1".to_string(),
                 correlation_id: D2bCorrelationId::from_sensitive("test", "session-1"),
@@ -1341,6 +1509,9 @@ mod imp {
                 label: "quiet-otter".to_string(),
                 vm_name: "work".to_string(),
                 workspace: Some("private".to_string()),
+                state: ShellSessionState::Detached,
+                attached: false,
+                is_default: false,
                 correlation_id: D2bCorrelationId::from_sensitive("session", "session-secret"),
             };
             let handle = handle();
@@ -1390,11 +1561,14 @@ mod imp {
                     label: "work".to_string(),
                     vm_name: "work".to_string(),
                     workspace: None,
+                    state: ShellSessionState::Detached,
+                    attached: false,
+                    is_default: false,
                     correlation_id: D2bCorrelationId::from_sensitive("session", "session-1"),
                 }],
                 ..Default::default()
             });
-            let domain = D2bDomain::new("d2b", transport);
+            let domain = D2bDomain::new("d2b", "work", transport);
 
             let sessions = smol::block_on(domain.discover_sessions()).unwrap();
             assert_eq!(sessions[0].id, "session-1");
@@ -1465,7 +1639,7 @@ mod imp {
         #[test]
         fn domain_detach_detaches_tracked_panes() {
             let transport = Arc::new(FakeTransport::default());
-            let domain = D2bDomain::new("d2b", transport.clone());
+            let domain = D2bDomain::new("d2b", "work", transport.clone());
             let pane = D2bPane::new(1, size(), attached_with_transport(&transport));
             domain.panes.lock().push(Arc::downgrade(&pane));
 
@@ -1555,6 +1729,63 @@ mod imp {
                 wait_for(|| pane.is_dead());
                 assert!(pane.is_dead(), "{}", expected);
             }
+        }
+
+        #[test]
+        fn d2b_title_format_prefixes_vm_and_session() {
+            assert_eq!(
+                super::super::d2b_tab_title("work", "build", ""),
+                "[work:build]"
+            );
+            assert_eq!(
+                super::super::d2b_tab_title("work", "build", "nvim"),
+                "[work:build] nvim"
+            );
+            assert_eq!(
+                super::super::d2b_tab_title("work", "build", "wezterm"),
+                "[work:build]"
+            );
+        }
+
+        #[test]
+        fn shell_name_validation_matches_d2b_grammar() {
+            for name in ["default", "build_1", "a.b-c", "9"] {
+                assert!(super::super::validate_shell_name(name).is_ok(), "{}", name);
+            }
+            for name in ["", "-bad", "has space", "slash/name", "{tmpl}"] {
+                assert!(super::super::validate_shell_name(name).is_err(), "{}", name);
+            }
+        }
+
+        #[test]
+        fn spawn_command_env_selects_d2b_session_without_subprocess_bridge() {
+            let transport = FakeTransport::default();
+            let mut command = portable_pty::CommandBuilder::new_default_prog();
+            command.env(super::super::D2B_SHELL_NAME_ENV, "build");
+            let session_id = d2b_session_from_command(Some(command)).unwrap();
+
+            let attached = smol::block_on(transport.attach(D2bAttachRequest {
+                session_id,
+                size: size(),
+            }))
+            .unwrap();
+            let pane = D2bPane::new(1, size(), attached);
+
+            assert_eq!(
+                transport.attach_requests.lock()[0].session_id.as_deref(),
+                Some("build")
+            );
+            assert_eq!(pane.get_title(), "[work:build]");
+        }
+
+        #[test]
+        fn vm_mux_socket_path_is_unique_per_vm_and_not_global() {
+            let base = PathBuf::from("runtime");
+            let work = super::super::vm_mux_socket_path(&base, "work");
+            let personal = super::super::vm_mux_socket_path(&base, "personal");
+            assert_ne!(work, personal);
+            assert!(work.to_string_lossy().contains("d2b-work"));
+            assert!(!work.ends_with("sock"));
         }
     }
 }

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -1,0 +1,793 @@
+#[cfg(target_os = "linux")]
+mod imp {
+    use crate::domain::{alloc_domain_id, Domain, DomainId, DomainState};
+    use crate::pane::{alloc_pane_id, CachePolicy, CloseReason, LogicalLine, Pane, PaneId};
+    use crate::renderable::{
+        terminal_for_each_logical_line_in_stable_range_mut, terminal_get_cursor_position,
+        terminal_get_dimensions, terminal_get_dirty_lines, terminal_get_lines,
+        terminal_with_lines_mut, RenderableDimensions, StableCursorPosition,
+    };
+    use crate::window::WindowId;
+    use crate::Mux;
+    use anyhow::{anyhow, bail};
+    use async_trait::async_trait;
+    use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
+    use rangeset::RangeSet;
+    use std::future::Future;
+    use std::io::{Error as IoError, ErrorKind, Write};
+    use std::ops::Range;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::sync::{Arc, Weak};
+    use termwiz::surface::{Line, SequenceNo};
+    use url::Url;
+    use wezterm_term::color::ColorPalette;
+    use wezterm_term::{
+        KeyCode, KeyModifiers, MouseEvent, StableRowIndex, TerminalConfiguration, TerminalSize,
+    };
+
+    pub type TransportFuture<'a, T> = Pin<Box<dyn Future<Output = anyhow::Result<T>> + Send + 'a>>;
+
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct D2bSession {
+        pub id: String,
+        pub label: String,
+        pub vm_name: String,
+        pub workspace: Option<String>,
+    }
+
+    impl std::fmt::Debug for D2bSession {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("D2bSession")
+                .field("id", &"<redacted>")
+                .field("label", &"<redacted>")
+                .field("vm_name", &"<redacted>")
+                .field("workspace", &self.workspace.as_ref().map(|_| "<redacted>"))
+                .finish()
+        }
+    }
+
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct D2bPaneHandle {
+        pub session_id: String,
+        pub pane_id: String,
+    }
+
+    impl std::fmt::Debug for D2bPaneHandle {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("D2bPaneHandle")
+                .field("session_id", &"<redacted>")
+                .field("pane_id", &"<redacted>")
+                .finish()
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum D2bDetachReason {
+        PaneClose,
+        PaneKill,
+        Drop,
+        DomainDetach,
+    }
+
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct D2bAttachRequest {
+        pub session_id: Option<String>,
+        pub size: TerminalSize,
+    }
+
+    impl std::fmt::Debug for D2bAttachRequest {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("D2bAttachRequest")
+                .field(
+                    "session_id",
+                    &self.session_id.as_ref().map(|_| "<redacted>"),
+                )
+                .field("size", &self.size)
+                .finish()
+        }
+    }
+
+    pub trait D2bTransport: Send + Sync {
+        fn discover_sessions(&self) -> TransportFuture<'_, Vec<D2bSession>>;
+
+        fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bPaneHandle>;
+
+        fn detach(
+            &self,
+            handle: &D2bPaneHandle,
+            reason: D2bDetachReason,
+        ) -> TransportFuture<'_, ()>;
+
+        fn send_input(&self, handle: &D2bPaneHandle, input: Vec<u8>) -> TransportFuture<'_, ()>;
+
+        fn resize(&self, handle: &D2bPaneHandle, size: TerminalSize) -> TransportFuture<'_, ()>;
+    }
+
+    pub struct D2bDomain {
+        id: DomainId,
+        name: String,
+        transport: Arc<dyn D2bTransport>,
+        state: Mutex<DomainState>,
+        panes: Mutex<Vec<Weak<D2bPane>>>,
+    }
+
+    impl D2bDomain {
+        pub fn new(name: impl Into<String>, transport: Arc<dyn D2bTransport>) -> Self {
+            Self {
+                id: alloc_domain_id(),
+                name: name.into(),
+                transport,
+                state: Mutex::new(DomainState::Detached),
+                panes: Mutex::new(Vec::new()),
+            }
+        }
+
+        pub async fn discover_sessions(&self) -> anyhow::Result<Vec<D2bSession>> {
+            self.transport.discover_sessions().await
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl Domain for D2bDomain {
+        async fn spawn_pane(
+            &self,
+            size: TerminalSize,
+            command: Option<portable_pty::CommandBuilder>,
+            _command_dir: Option<String>,
+        ) -> anyhow::Result<Arc<dyn Pane>> {
+            if command.is_some() {
+                bail!("d2b domains attach existing sessions; command spawning is unsupported");
+            }
+
+            let handle = self
+                .transport
+                .attach(D2bAttachRequest {
+                    session_id: None,
+                    size,
+                })
+                .await?;
+
+            let concrete_pane = Arc::new(D2bPane::new(
+                self.id,
+                size,
+                handle,
+                Arc::clone(&self.transport),
+            ));
+            self.panes.lock().push(Arc::downgrade(&concrete_pane));
+            let pane: Arc<dyn Pane> = concrete_pane;
+            Mux::get().add_pane(&pane)?;
+            Ok(pane)
+        }
+
+        fn spawnable(&self) -> bool {
+            true
+        }
+
+        fn detachable(&self) -> bool {
+            true
+        }
+
+        fn domain_id(&self) -> DomainId {
+            self.id
+        }
+
+        fn domain_name(&self) -> &str {
+            &self.name
+        }
+
+        async fn domain_label(&self) -> String {
+            match self.discover_sessions().await {
+                Ok(sessions) if sessions.is_empty() => format!("d2b `{}` — no sessions", self.name),
+                Ok(sessions) => format!("d2b `{}` — {} session(s)", self.name, sessions.len()),
+                Err(err) => {
+                    log::debug!("d2b session discovery failed for {}: {err:#}", self.name);
+                    format!("d2b `{}` — unavailable", self.name)
+                }
+            }
+        }
+
+        async fn attach(&self, _window_id: Option<WindowId>) -> anyhow::Result<()> {
+            *self.state.lock() = DomainState::Attached;
+            Ok(())
+        }
+
+        fn detach(&self) -> anyhow::Result<()> {
+            *self.state.lock() = DomainState::Detached;
+            let mut panes = self.panes.lock();
+            panes.retain(|pane| {
+                if let Some(pane) = pane.upgrade() {
+                    pane.detach_non_destructive(D2bDetachReason::DomainDetach);
+                    true
+                } else {
+                    false
+                }
+            });
+            Ok(())
+        }
+
+        fn state(&self) -> DomainState {
+            *self.state.lock()
+        }
+    }
+
+    pub struct D2bPane {
+        pane_id: PaneId,
+        domain_id: DomainId,
+        terminal: Mutex<wezterm_term::Terminal>,
+        writer: Mutex<Box<dyn Write + Send>>,
+        handle: D2bPaneHandle,
+        transport: Arc<dyn D2bTransport>,
+        input_tx: mpsc::Sender<Vec<u8>>,
+        detached: AtomicBool,
+    }
+
+    impl D2bPane {
+        pub fn new(
+            domain_id: DomainId,
+            size: TerminalSize,
+            handle: D2bPaneHandle,
+            transport: Arc<dyn D2bTransport>,
+        ) -> Self {
+            let pane_id = alloc_pane_id();
+            let (input_tx, input_rx) = mpsc::channel::<Vec<u8>>();
+            spawn_input_forwarder(Arc::clone(&transport), handle.clone(), input_rx);
+
+            let terminal = wezterm_term::Terminal::new(
+                size,
+                Arc::new(config::TermConfig::new()),
+                config::branding::APP_NAME_DISPLAY,
+                config::wezterm_version(),
+                Box::new(D2bInputWriter {
+                    input_tx: input_tx.clone(),
+                }),
+            );
+
+            Self {
+                pane_id,
+                domain_id,
+                terminal: Mutex::new(terminal),
+                writer: Mutex::new(Box::new(D2bInputWriter {
+                    input_tx: input_tx.clone(),
+                })),
+                handle,
+                transport,
+                input_tx,
+                detached: AtomicBool::new(false),
+            }
+        }
+
+        fn detach_non_destructive(&self, reason: D2bDetachReason) {
+            if self.detached.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            let transport = Arc::clone(&self.transport);
+            let handle = self.handle.clone();
+            smol::spawn(async move {
+                if let Err(err) = transport.detach(&handle, reason).await {
+                    log::warn!("failed to detach d2b pane: {err:#}");
+                }
+            })
+            .detach();
+        }
+
+        pub fn close_non_destructive(&self) {
+            self.detach_non_destructive(D2bDetachReason::PaneClose)
+        }
+    }
+
+    impl Pane for D2bPane {
+        fn pane_id(&self) -> PaneId {
+            self.pane_id
+        }
+
+        fn get_cursor_position(&self) -> StableCursorPosition {
+            terminal_get_cursor_position(&mut self.terminal.lock())
+        }
+
+        fn get_current_seqno(&self) -> SequenceNo {
+            self.terminal.lock().current_seqno()
+        }
+
+        fn get_changed_since(
+            &self,
+            lines: Range<StableRowIndex>,
+            seqno: SequenceNo,
+        ) -> RangeSet<StableRowIndex> {
+            terminal_get_dirty_lines(&mut self.terminal.lock(), lines, seqno)
+        }
+
+        fn get_lines(&self, lines: Range<StableRowIndex>) -> (StableRowIndex, Vec<Line>) {
+            terminal_get_lines(&mut self.terminal.lock(), lines)
+        }
+
+        fn with_lines_mut(
+            &self,
+            lines: Range<StableRowIndex>,
+            with_lines: &mut dyn crate::pane::WithPaneLines,
+        ) {
+            terminal_with_lines_mut(&mut self.terminal.lock(), lines, with_lines)
+        }
+
+        fn for_each_logical_line_in_stable_range_mut(
+            &self,
+            lines: Range<StableRowIndex>,
+            for_line: &mut dyn crate::pane::ForEachPaneLogicalLine,
+        ) {
+            terminal_for_each_logical_line_in_stable_range_mut(
+                &mut self.terminal.lock(),
+                lines,
+                for_line,
+            );
+        }
+
+        fn get_logical_lines(&self, lines: Range<StableRowIndex>) -> Vec<LogicalLine> {
+            crate::pane::impl_get_logical_lines_via_get_lines(self, lines)
+        }
+
+        fn get_dimensions(&self) -> RenderableDimensions {
+            terminal_get_dimensions(&mut self.terminal.lock())
+        }
+
+        fn get_title(&self) -> String {
+            self.terminal.lock().get_title().to_string()
+        }
+
+        fn send_paste(&self, text: &str) -> anyhow::Result<()> {
+            self.input_tx
+                .send(text.as_bytes().to_vec())
+                .map_err(|err| anyhow!("d2b input queue closed: {err}"))
+        }
+
+        fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
+            Ok(None)
+        }
+
+        fn writer(&self) -> MappedMutexGuard<'_, dyn Write> {
+            MutexGuard::map(self.writer.lock(), |writer| {
+                let w: &mut dyn Write = writer.as_mut();
+                w
+            })
+        }
+
+        fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {
+            self.terminal.lock().resize(size);
+            let transport = Arc::clone(&self.transport);
+            let handle = self.handle.clone();
+            smol::spawn(async move {
+                if let Err(err) = transport.resize(&handle, size).await {
+                    log::warn!("failed to resize d2b pane: {err:#}");
+                }
+            })
+            .detach();
+            Ok(())
+        }
+
+        fn key_down(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()> {
+            self.terminal.lock().key_down(key, mods)
+        }
+
+        fn key_up(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()> {
+            self.terminal.lock().key_up(key, mods)
+        }
+
+        fn mouse_event(&self, event: MouseEvent) -> anyhow::Result<()> {
+            self.terminal.lock().mouse_event(event)
+        }
+
+        fn perform_actions(&self, actions: Vec<termwiz::escape::Action>) {
+            self.terminal.lock().perform_actions(actions)
+        }
+
+        fn is_dead(&self) -> bool {
+            self.detached.load(Ordering::SeqCst)
+        }
+
+        fn kill(&self) {
+            self.detach_non_destructive(D2bDetachReason::PaneKill);
+        }
+
+        fn palette(&self) -> ColorPalette {
+            self.terminal.lock().palette()
+        }
+
+        fn domain_id(&self) -> DomainId {
+            self.domain_id
+        }
+
+        fn can_close_without_prompting(&self, _reason: CloseReason) -> bool {
+            true
+        }
+
+        fn is_mouse_grabbed(&self) -> bool {
+            self.terminal.lock().is_mouse_grabbed()
+        }
+
+        fn is_alt_screen_active(&self) -> bool {
+            self.terminal.lock().is_alt_screen_active()
+        }
+
+        fn get_current_working_dir(&self, _policy: CachePolicy) -> Option<Url> {
+            self.terminal.lock().get_current_dir().cloned()
+        }
+
+        fn set_config(&self, config: Arc<dyn TerminalConfiguration>) {
+            self.terminal.lock().set_config(config);
+        }
+
+        fn get_config(&self) -> Option<Arc<dyn TerminalConfiguration>> {
+            Some(self.terminal.lock().get_config())
+        }
+    }
+
+    impl Drop for D2bPane {
+        fn drop(&mut self) {
+            self.detach_non_destructive(D2bDetachReason::Drop);
+        }
+    }
+
+    struct D2bInputWriter {
+        input_tx: mpsc::Sender<Vec<u8>>,
+    }
+
+    impl Write for D2bInputWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.input_tx.send(buf.to_vec()).map_err(|err| {
+                IoError::new(
+                    ErrorKind::BrokenPipe,
+                    format!("d2b input queue closed: {err}"),
+                )
+            })?;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn spawn_input_forwarder(
+        transport: Arc<dyn D2bTransport>,
+        handle: D2bPaneHandle,
+        input_rx: mpsc::Receiver<Vec<u8>>,
+    ) {
+        std::thread::Builder::new()
+            .name("weezterm-d2b-input".to_string())
+            .spawn(move || {
+                while let Ok(input) = input_rx.recv() {
+                    if let Err(err) = smol::block_on(transport.send_input(&handle, input)) {
+                        log::warn!("d2b input forward failed: {err:#}");
+                        break;
+                    }
+                }
+            })
+            .expect("spawn d2b input forwarder");
+    }
+
+    pub struct UnsupportedD2bTransport;
+
+    impl D2bTransport for UnsupportedD2bTransport {
+        fn discover_sessions(&self) -> TransportFuture<'_, Vec<D2bSession>> {
+            Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
+        }
+
+        fn attach(&self, _request: D2bAttachRequest) -> TransportFuture<'_, D2bPaneHandle> {
+            Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
+        }
+
+        fn detach(
+            &self,
+            _handle: &D2bPaneHandle,
+            _reason: D2bDetachReason,
+        ) -> TransportFuture<'_, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn send_input(&self, _handle: &D2bPaneHandle, _input: Vec<u8>) -> TransportFuture<'_, ()> {
+            Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
+        }
+
+        fn resize(&self, _handle: &D2bPaneHandle, _size: TerminalSize) -> TransportFuture<'_, ()> {
+            Box::pin(async { Err(anyhow!("native d2b transport is not wired yet")) })
+        }
+    }
+
+    pub fn unsupported_domain(name: impl Into<String>) -> D2bDomain {
+        D2bDomain::new(name, Arc::new(UnsupportedD2bTransport))
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+        use parking_lot::Mutex;
+
+        #[derive(Default)]
+        struct FakeTransport {
+            sessions: Vec<D2bSession>,
+            detach_calls: Mutex<Vec<D2bDetachReason>>,
+            inputs: Mutex<Vec<Vec<u8>>>,
+            resizes: Mutex<Vec<TerminalSize>>,
+        }
+
+        impl D2bTransport for FakeTransport {
+            fn discover_sessions(&self) -> TransportFuture<'_, Vec<D2bSession>> {
+                let sessions = self.sessions.clone();
+                Box::pin(async move { Ok(sessions) })
+            }
+
+            fn attach(&self, request: D2bAttachRequest) -> TransportFuture<'_, D2bPaneHandle> {
+                Box::pin(async move {
+                    Ok(D2bPaneHandle {
+                        session_id: request
+                            .session_id
+                            .unwrap_or_else(|| "session-1".to_string()),
+                        pane_id: "pane-1".to_string(),
+                    })
+                })
+            }
+
+            fn detach(
+                &self,
+                _handle: &D2bPaneHandle,
+                reason: D2bDetachReason,
+            ) -> TransportFuture<'_, ()> {
+                Box::pin(async move {
+                    self.detach_calls.lock().push(reason);
+                    Ok(())
+                })
+            }
+
+            fn send_input(
+                &self,
+                _handle: &D2bPaneHandle,
+                input: Vec<u8>,
+            ) -> TransportFuture<'_, ()> {
+                Box::pin(async move {
+                    self.inputs.lock().push(input);
+                    Ok(())
+                })
+            }
+
+            fn resize(
+                &self,
+                _handle: &D2bPaneHandle,
+                size: TerminalSize,
+            ) -> TransportFuture<'_, ()> {
+                Box::pin(async move {
+                    self.resizes.lock().push(size);
+                    Ok(())
+                })
+            }
+        }
+
+        fn size() -> TerminalSize {
+            TerminalSize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 640,
+                pixel_height: 480,
+                dpi: 96,
+            }
+        }
+
+        fn handle() -> D2bPaneHandle {
+            D2bPaneHandle {
+                session_id: "session-1".to_string(),
+                pane_id: "pane-1".to_string(),
+            }
+        }
+
+        #[test]
+        fn debug_redacts_session_and_handle_data() {
+            let session = D2bSession {
+                id: "session-secret".to_string(),
+                label: "quiet-otter".to_string(),
+                vm_name: "work".to_string(),
+                workspace: Some("private".to_string()),
+            };
+            let handle = handle();
+            let attach = D2bAttachRequest {
+                session_id: Some("session-secret".to_string()),
+                size: size(),
+            };
+
+            for rendered in [
+                format!("{session:?}"),
+                format!("{handle:?}"),
+                format!("{attach:?}"),
+            ] {
+                assert!(!rendered.contains("session-secret"));
+                assert!(!rendered.contains("quiet-otter"));
+                assert!(rendered.contains("redacted"));
+            }
+        }
+
+        fn wait_for<F>(mut predicate: F)
+        where
+            F: FnMut() -> bool,
+        {
+            for _ in 0..50 {
+                if predicate() {
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            assert!(predicate());
+        }
+
+        #[test]
+        fn discovery_uses_transport_without_d2bd() {
+            let transport = Arc::new(FakeTransport {
+                sessions: vec![D2bSession {
+                    id: "session-1".to_string(),
+                    label: "work".to_string(),
+                    vm_name: "work".to_string(),
+                    workspace: None,
+                }],
+                ..Default::default()
+            });
+            let domain = D2bDomain::new("d2b", transport);
+
+            let sessions = smol::block_on(domain.discover_sessions()).unwrap();
+            assert_eq!(sessions[0].id, "session-1");
+        }
+
+        #[test]
+        fn kill_detaches_without_destroying_session() {
+            let transport = Arc::new(FakeTransport::default());
+            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+
+            pane.kill();
+            pane.kill();
+            drop(pane);
+
+            wait_for(|| !transport.detach_calls.lock().is_empty());
+            assert_eq!(
+                *transport.detach_calls.lock(),
+                vec![D2bDetachReason::PaneKill]
+            );
+        }
+
+        #[test]
+        fn drop_detaches_if_pane_was_not_closed() {
+            let transport = Arc::new(FakeTransport::default());
+            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+
+            drop(pane);
+
+            wait_for(|| !transport.detach_calls.lock().is_empty());
+            assert_eq!(*transport.detach_calls.lock(), vec![D2bDetachReason::Drop]);
+        }
+
+        #[test]
+        fn explicit_close_uses_detach_not_kill() {
+            let transport = Arc::new(FakeTransport::default());
+            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+
+            pane.close_non_destructive();
+            drop(pane);
+
+            wait_for(|| !transport.detach_calls.lock().is_empty());
+            assert_eq!(
+                *transport.detach_calls.lock(),
+                vec![D2bDetachReason::PaneClose]
+            );
+        }
+
+        #[test]
+        fn domain_detach_detaches_tracked_panes() {
+            let transport = Arc::new(FakeTransport::default());
+            let domain = D2bDomain::new("d2b", transport.clone());
+            let pane = Arc::new(D2bPane::new(1, size(), handle(), transport.clone()));
+            domain.panes.lock().push(Arc::downgrade(&pane));
+
+            domain.detach().unwrap();
+            drop(pane);
+
+            wait_for(|| !transport.detach_calls.lock().is_empty());
+            assert_eq!(
+                *transport.detach_calls.lock(),
+                vec![D2bDetachReason::DomainDetach]
+            );
+        }
+
+        #[test]
+        fn paste_and_resize_use_transport() {
+            let transport = Arc::new(FakeTransport::default());
+            let pane = D2bPane::new(1, size(), handle(), transport.clone());
+
+            pane.send_paste("hello").unwrap();
+            pane.resize(TerminalSize {
+                rows: 40,
+                cols: 100,
+                pixel_width: 800,
+                pixel_height: 600,
+                dpi: 96,
+            })
+            .unwrap();
+
+            wait_for(|| !transport.inputs.lock().is_empty());
+            wait_for(|| !transport.resizes.lock().is_empty());
+            assert_eq!(*transport.inputs.lock(), vec![b"hello".to_vec()]);
+            assert_eq!(transport.resizes.lock()[0].rows, 40);
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use crate::domain::{alloc_domain_id, Domain, DomainId, DomainState, SplitSource};
+    use crate::pane::{Pane, PaneId};
+    use crate::tab::{SplitRequest, Tab, TabId};
+    use crate::window::WindowId;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use wezterm_term::TerminalSize;
+
+    pub struct D2bDomain;
+
+    impl D2bDomain {
+        pub fn unsupported() -> anyhow::Result<Self> {
+            anyhow::bail!("native d2b domains are only supported on Linux")
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl Domain for D2bDomain {
+        async fn spawn_pane(
+            &self,
+            _size: TerminalSize,
+            _command: Option<portable_pty::CommandBuilder>,
+            _command_dir: Option<String>,
+        ) -> anyhow::Result<Arc<dyn Pane>> {
+            anyhow::bail!("native d2b domains are only supported on Linux")
+        }
+
+        async fn spawn(
+            &self,
+            _size: TerminalSize,
+            _command: Option<portable_pty::CommandBuilder>,
+            _command_dir: Option<String>,
+            _window: WindowId,
+        ) -> anyhow::Result<Arc<Tab>> {
+            anyhow::bail!("native d2b domains are only supported on Linux")
+        }
+
+        async fn split_pane(
+            &self,
+            _source: SplitSource,
+            _tab: TabId,
+            _pane_id: PaneId,
+            _split_request: SplitRequest,
+        ) -> anyhow::Result<Arc<dyn Pane>> {
+            anyhow::bail!("native d2b domains are only supported on Linux")
+        }
+
+        fn detachable(&self) -> bool {
+            false
+        }
+
+        fn domain_id(&self) -> DomainId {
+            alloc_domain_id()
+        }
+
+        fn domain_name(&self) -> &str {
+            "d2b"
+        }
+
+        async fn attach(&self, _window_id: Option<WindowId>) -> anyhow::Result<()> {
+            anyhow::bail!("native d2b domains are only supported on Linux")
+        }
+
+        fn detach(&self) -> anyhow::Result<()> {
+            anyhow::bail!("native d2b domains are only supported on Linux")
+        }
+
+        fn state(&self) -> DomainState {
+            DomainState::Detached
+        }
+    }
+}
+
+pub use imp::*;

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -36,6 +36,7 @@ use winapi::um::winsock2::{SOL_SOCKET, SO_RCVBUF, SO_SNDBUF};
 pub mod activity;
 pub mod client;
 pub mod connui;
+pub mod d2b;
 pub mod domain;
 pub mod localpane;
 pub mod pane;

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -7,16 +7,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1783281408,
-        "narHash": "sha256-TO1aDZnvHGB0kodpbyGPwSAhwFtV2rv0FQj3pUZQR/g=",
+        "lastModified": 1783289531,
+        "narHash": "sha256-oZJ76XrHajbdm3YsRu0qe+PsGZkscDYBjdR0iD4YzY0=",
         "owner": "vicondoa",
         "repo": "d2b-toolkit",
-        "rev": "e93b17ab7fcce8a5a9f232c3c411f8082e56b706",
+        "rev": "1c359ae97472d91d75113d08ac13a1c153cbe088",
         "type": "github"
       },
       "original": {
         "owner": "vicondoa",
-        "ref": "terminal-integration-toolkit",
         "repo": "d2b-toolkit",
         "type": "github"
       }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "d2b-toolkit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783281408,
+        "narHash": "sha256-TO1aDZnvHGB0kodpbyGPwSAhwFtV2rv0FQj3pUZQR/g=",
+        "owner": "vicondoa",
+        "repo": "d2b-toolkit",
+        "rev": "e93b17ab7fcce8a5a9f232c3c411f8082e56b706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vicondoa",
+        "ref": "terminal-integration-toolkit",
+        "repo": "d2b-toolkit",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -87,6 +108,7 @@
     },
     "root": {
       "inputs": {
+        "d2b-toolkit": "d2b-toolkit",
         "flake-utils": "flake-utils",
         "freetype2": "freetype2",
         "harfbuzz": "harfbuzz",

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -14,7 +14,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     d2b-toolkit = {
-      url = "github:vicondoa/d2b-toolkit/terminal-integration-toolkit";
+      url = "github:vicondoa/d2b-toolkit";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -13,6 +13,10 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    d2b-toolkit = {
+      url = "github:vicondoa/d2b-toolkit/terminal-integration-toolkit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     # NOTE: @2024-05 Nix flakes does not support getting git submodules of 'self'.
     # refs:
@@ -53,6 +57,7 @@
 
         inherit (inputs.nixpkgs) lib;
         inherit (pkgs) stdenv;
+        toolkitSource = inputs.d2b-toolkit.packages.${system}.default;
 
         nativeBuildInputs =
           with pkgs;
@@ -154,6 +159,12 @@
 
           postPatch = ''
             echo ${version} > .tag
+
+            substituteInPlace mux/Cargo.toml \
+              --replace-fail "../../d2b-toolkit/crates/d2b-client" \
+                "${toolkitSource}/share/d2b-toolkit/crates/d2b-client" \
+              --replace-fail "../../d2b-toolkit/crates/d2b-toolkit-core" \
+                "${toolkitSource}/share/d2b-toolkit/crates/d2b-toolkit-core"
 
             # tests are failing with: Unable to exchange encryption keys
             rm -r wezterm-ssh/tests

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -1636,6 +1636,24 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Shell"],
             icon: None,
         },
+        // --- weezterm remote features ---
+        ShowD2bLauncher => CommandDef {
+            brief: "Show d2b sessions".into(),
+            doc: "Shows the native d2b VM session picker".into(),
+            keys: vec![],
+            args: &[ArgType::ActiveWindow],
+            menubar: &["Shell"],
+            icon: Some("md_terminal"),
+        },
+        D2bOpenSession { .. } => CommandDef {
+            brief: "Open d2b session".into(),
+            doc: "Opens or creates a native d2b VM shell session".into(),
+            keys: vec![],
+            args: &[ArgType::ActiveWindow],
+            menubar: &[],
+            icon: Some("md_terminal"),
+        },
+        // --- end weezterm remote features ---
         ShowTabNavigator => CommandDef {
             brief: "Navigate tabs".into(),
             doc: "Shows the tab navigator".into(),
@@ -2179,6 +2197,7 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         ShowLauncher,
         ShowTabNavigator,
         // --- weezterm remote features ---
+        ShowD2bLauncher,
         ShowPortForwardOverlay,
         ShowConfigOverlay,
         ShowDevContainerManager,

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -451,16 +451,22 @@ fn cell_pixel_dims(config: &ConfigHandle, dpi: f64) -> anyhow::Result<(usize, us
     ))
 }
 
+fn gui_mux_socket_path_for_domain(domain: Option<&str>) -> PathBuf {
+    if let Some(vm) =
+        d2b_vm_for_domain_name(domain).or_else(|| std::env::var(mux::d2b::D2B_BOUND_VM_ENV).ok())
+    {
+        mux::d2b::vm_mux_socket_path(&config::RUNTIME_DIR, &vm)
+    } else {
+        config::RUNTIME_DIR.join(format!("gui-sock-{}", unsafe { libc::getpid() }))
+    }
+}
+
 async fn async_run_terminal_gui(
     cmd: Option<CommandBuilder>,
     opts: StartCommand,
     should_publish: bool,
 ) -> anyhow::Result<()> {
-    let unix_socket_path = d2b_vm_for_domain_name(opts.domain.as_deref())
-        .map(|vm| mux::d2b::vm_mux_socket_path(&config::RUNTIME_DIR, &vm))
-        .unwrap_or_else(|| {
-            config::RUNTIME_DIR.join(format!("gui-sock-{}", unsafe { libc::getpid() }))
-        });
+    let unix_socket_path = gui_mux_socket_path_for_domain(opts.domain.as_deref());
     std::env::set_var("WEZTERM_UNIX_SOCKET", unix_socket_path.clone());
     wezterm_blob_leases::register_storage(Arc::new(
         wezterm_blob_leases::simple_tempdir::SimpleTempDir::new_in(&*config::CACHE_DIR)?,

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -374,6 +374,34 @@ async fn connect_to_auto_connect_domains() -> anyhow::Result<()> {
     Ok(())
 }
 
+// --- weezterm remote features ---
+#[cfg(target_os = "linux")]
+fn d2b_vm_for_domain_name(domain_name: Option<&str>) -> Option<String> {
+    let mux = Mux::try_get()?;
+    let domain = match domain_name {
+        Some(domain_name) => mux.get_domain_by_name(domain_name)?,
+        None => mux.default_domain(),
+    };
+    domain
+        .downcast_ref::<mux::d2b::D2bDomain>()
+        .map(|domain| domain.vm_name().to_string())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn d2b_vm_for_domain_name(_domain_name: Option<&str>) -> Option<String> {
+    None
+}
+
+fn d2b_vm_from_config_domain(config: &ConfigHandle, domain_name: Option<&str>) -> Option<String> {
+    let domain_name = domain_name?;
+    config
+        .d2b_domains
+        .iter()
+        .find(|domain| domain.name == domain_name)
+        .map(|domain| domain.vm.clone())
+}
+// --- end weezterm remote features ---
+
 async fn trigger_gui_startup(
     lua: Option<Rc<mlua::Lua>>,
     spawn: Option<SpawnCommand>,
@@ -428,8 +456,11 @@ async fn async_run_terminal_gui(
     opts: StartCommand,
     should_publish: bool,
 ) -> anyhow::Result<()> {
-    let unix_socket_path =
-        config::RUNTIME_DIR.join(format!("gui-sock-{}", unsafe { libc::getpid() }));
+    let unix_socket_path = d2b_vm_for_domain_name(opts.domain.as_deref())
+        .map(|vm| mux::d2b::vm_mux_socket_path(&config::RUNTIME_DIR, &vm))
+        .unwrap_or_else(|| {
+            config::RUNTIME_DIR.join(format!("gui-sock-{}", unsafe { libc::getpid() }))
+        });
     std::env::set_var("WEZTERM_UNIX_SOCKET", unix_socket_path.clone());
     wezterm_blob_leases::register_storage(Arc::new(
         wezterm_blob_leases::simple_tempdir::SimpleTempDir::new_in(&*config::CACHE_DIR)?,
@@ -764,6 +795,19 @@ fn run_terminal_gui(opts: StartCommand, default_domain_name: Option<String>) -> 
 
     let config = config::configuration();
 
+    // --- weezterm remote features ---
+    let requested_domain = opts
+        .domain
+        .as_deref()
+        .or(default_domain_name.as_deref())
+        .or(config.default_domain.as_deref());
+    if let Some(vm) = d2b_vm_from_config_domain(&config, requested_domain) {
+        std::env::set_var(mux::d2b::D2B_BOUND_VM_ENV, vm);
+    } else {
+        std::env::remove_var(mux::d2b::D2B_BOUND_VM_ENV);
+    }
+    // --- end weezterm remote features ---
+
     let cmd = if !opts.prog.is_empty() || opts.cwd.is_some() {
         let prog = opts.prog.iter().map(|s| s.as_os_str()).collect::<Vec<_>>();
         let mut builder = config.build_prog(
@@ -806,10 +850,11 @@ fn run_terminal_gui(opts: StartCommand, default_domain_name: Option<String>) -> 
     // First, let's see if we can ask an already running wezterm to do this.
     // We must do this before we start the gui frontend as the scheduler
     // requirements are different.
+    let is_d2b_vm_domain = d2b_vm_for_domain_name(opts.domain.as_deref()).is_some();
     let mut publish = Publish::resolve(
         &mux,
         &config,
-        opts.always_new_process || opts.position.is_some(),
+        opts.always_new_process || opts.position.is_some() || is_d2b_vm_domain,
     );
     log::trace!("{:?}", publish);
     if publish.try_spawn(
@@ -1270,6 +1315,9 @@ fn run() -> anyhow::Result<()> {
     if let Some(value) = &config.default_ssh_auth_sock {
         std::env::set_var("SSH_AUTH_SOCK", value);
     }
+    // --- weezterm remote features ---
+    std::env::remove_var(mux::d2b::D2B_BOUND_VM_ENV);
+    // --- end weezterm remote features ---
 
     let sub = match opts.cmd.as_ref().cloned() {
         Some(SubCommand::BlockingStart(start)) => {

--- a/wezterm-gui/src/overlay/d2b_launcher.rs
+++ b/wezterm-gui/src/overlay/d2b_launcher.rs
@@ -1,0 +1,554 @@
+use crate::overlay::quickselect;
+use crate::termwindow::TermWindowNotif;
+use config::keyassignment::KeyAssignment;
+use mux::d2b::{friendly_session_name, validate_shell_name, D2bDomain, D2bSession};
+use mux::domain::Domain;
+use mux::termwiztermtab::TermWizTerminal;
+use mux::Mux;
+use termwiz::cell::{AttributeChange, CellAttributes, Intensity};
+use termwiz::color::ColorAttribute;
+use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers, MouseButtons, MouseEvent};
+use termwiz::surface::{Change, Position};
+use termwiz::terminal::Terminal;
+use termwiz_funcs::truncate_right;
+use window::WindowOps;
+
+const ROW_OVERHEAD: usize = 3;
+const ALPHABET: &str = "1234567890abcdefghilmnopqrstuvwxyz";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct D2bVmPickerEntry {
+    pub domain_name: String,
+    pub vm_name: String,
+    pub available: bool,
+    pub sessions: Vec<D2bSession>,
+    pub generated_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum EntryAction {
+    Open {
+        domain: String,
+        name: String,
+    },
+    Manual {
+        domain: String,
+        default_name: String,
+    },
+    Disabled,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Entry {
+    label: String,
+    disabled: bool,
+    action: EntryAction,
+}
+
+#[derive(Clone, Debug)]
+pub struct D2bLauncherArgs {
+    pane_id: mux::pane::PaneId,
+    vms: Vec<D2bVmPickerEntry>,
+}
+
+impl D2bLauncherArgs {
+    pub async fn new(pane_id: mux::pane::PaneId) -> Self {
+        let mux = Mux::get();
+        let mut vms = vec![];
+        for domain in mux.iter_domains() {
+            let Some(d2b) = domain.downcast_ref::<D2bDomain>() else {
+                continue;
+            };
+            let domain_name = d2b.domain_name().to_string();
+            let vm_name = d2b.vm_name().to_string();
+            match d2b.discover_sessions().await {
+                Ok(sessions) => {
+                    let names = sessions
+                        .iter()
+                        .map(|session| session.id.clone())
+                        .collect::<Vec<_>>();
+                    let generated_name = friendly_session_name(&vm_name, &names);
+                    vms.push(D2bVmPickerEntry {
+                        domain_name,
+                        vm_name,
+                        available: true,
+                        sessions,
+                        generated_name,
+                    });
+                }
+                Err(err) => {
+                    log::debug!("d2b discovery failed for {vm_name}: {err:#}");
+                    vms.push(D2bVmPickerEntry {
+                        domain_name,
+                        vm_name: vm_name.clone(),
+                        available: false,
+                        sessions: vec![],
+                        generated_name: friendly_session_name(&vm_name, &[]),
+                    });
+                }
+            }
+        }
+        vms.sort_by(|a, b| {
+            a.vm_name
+                .cmp(&b.vm_name)
+                .then(a.domain_name.cmp(&b.domain_name))
+        });
+        Self { pane_id, vms }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Mode {
+    Pick,
+    Prompt {
+        domain: String,
+        input: String,
+        error: Option<String>,
+    },
+}
+
+struct State {
+    args: D2bLauncherArgs,
+    window: ::window::Window,
+    entries: Vec<Entry>,
+    active_idx: usize,
+    top_row: usize,
+    max_items: usize,
+    labels: Vec<String>,
+    selection: String,
+    mode: Mode,
+}
+
+impl State {
+    fn new(args: D2bLauncherArgs, window: ::window::Window) -> Self {
+        Self {
+            entries: build_entries(&args.vms),
+            args,
+            window,
+            active_idx: 0,
+            top_row: 0,
+            max_items: 0,
+            labels: vec![],
+            selection: String::new(),
+            mode: Mode::Pick,
+        }
+    }
+
+    fn render(&mut self, term: &mut TermWizTerminal) -> termwiz::Result<()> {
+        match self.mode.clone() {
+            Mode::Pick => self.render_picker(term),
+            Mode::Prompt { input, error, .. } => self.render_prompt(term, &input, error.as_deref()),
+        }
+    }
+
+    fn render_picker(&mut self, term: &mut TermWizTerminal) -> termwiz::Result<()> {
+        let size = term.get_screen_size()?;
+        let max_width = size.cols.saturating_sub(6);
+        let max_items = size.rows.saturating_sub(ROW_OVERHEAD);
+        if max_items != self.max_items {
+            self.labels = quickselect::compute_labels_for_alphabet_with_preserved_case(
+                ALPHABET,
+                self.entries.len().min(max_items + 1),
+            );
+            self.max_items = max_items;
+        }
+
+        let mut changes = vec![
+            Change::ClearScreen(ColorAttribute::Default),
+            Change::CursorPosition {
+                x: Position::Absolute(0),
+                y: Position::Absolute(0),
+            },
+            Change::Text("d2b sessions: Enter=open  n=name new  Esc=cancel\r\n".to_string()),
+            Change::AllAttributes(CellAttributes::default()),
+        ];
+        let max_label_len = self.labels.iter().map(|s| s.len()).max().unwrap_or(0);
+        let mut labels = self.labels.iter();
+        for (row_num, (entry_idx, entry)) in self
+            .entries
+            .iter()
+            .enumerate()
+            .skip(self.top_row)
+            .enumerate()
+        {
+            if row_num > max_items {
+                break;
+            }
+            if entry_idx == self.active_idx {
+                changes.push(AttributeChange::Reverse(true).into());
+            }
+            if let Some(label) = labels.next() {
+                changes.push(Change::Text(format!(" {label:>max_label_len$}. ")));
+            } else {
+                changes.push(Change::Text(" ".repeat(max_label_len + 3)));
+            }
+            if entry.disabled {
+                changes.push(AttributeChange::Intensity(Intensity::Half).into());
+            }
+            changes.push(Change::Text(truncate_right(&entry.label, max_width)));
+            if entry.disabled {
+                changes.push(AttributeChange::Intensity(Intensity::Normal).into());
+            }
+            if entry_idx == self.active_idx {
+                changes.push(AttributeChange::Reverse(false).into());
+            }
+            changes.push(Change::AllAttributes(CellAttributes::default()));
+            changes.push(Change::Text("\r\n".to_string()));
+        }
+        term.render(&changes)
+    }
+
+    fn render_prompt(
+        &self,
+        term: &mut TermWizTerminal,
+        input: &str,
+        error: Option<&str>,
+    ) -> termwiz::Result<()> {
+        let mut changes = vec![
+            Change::ClearScreen(ColorAttribute::Default),
+            Change::CursorPosition {
+                x: Position::Absolute(0),
+                y: Position::Absolute(0),
+            },
+            Change::Text(
+                "Name new d2b shell (1-64 bytes, [A-Za-z0-9._-]); Enter=open Esc=cancel\r\n"
+                    .to_string(),
+            ),
+            Change::Text(format!("> {input}")),
+        ];
+        if let Some(error) = error {
+            changes.push(Change::Text(format!("\r\nInvalid name: {error}")));
+        }
+        term.render(&changes)
+    }
+
+    fn move_up(&mut self) {
+        self.active_idx = self.active_idx.saturating_sub(1);
+        if self.active_idx < self.top_row {
+            self.top_row = self.active_idx;
+        }
+    }
+
+    fn move_down(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        self.active_idx = (self.active_idx + 1).min(self.entries.len() - 1);
+        if self.active_idx > self.top_row + self.max_items {
+            self.top_row = self.active_idx.saturating_sub(self.max_items);
+        }
+    }
+
+    fn open(&self, domain: String, name: String) {
+        self.window.notify(TermWindowNotif::PerformAssignment {
+            pane_id: self.args.pane_id,
+            assignment: KeyAssignment::D2bOpenSession {
+                domain,
+                name: Some(name),
+            },
+            tx: None,
+        });
+    }
+
+    fn launch(&mut self, active_idx: usize) -> bool {
+        let Some(entry) = self.entries.get(active_idx).cloned() else {
+            return false;
+        };
+        match entry.action {
+            EntryAction::Open { domain, name } => {
+                self.open(domain, name);
+                true
+            }
+            EntryAction::Manual {
+                domain,
+                default_name,
+            } => {
+                self.mode = Mode::Prompt {
+                    domain,
+                    input: default_name,
+                    error: None,
+                };
+                false
+            }
+            EntryAction::Disabled => false,
+        }
+    }
+
+    fn run_loop(&mut self, term: &mut TermWizTerminal) -> anyhow::Result<()> {
+        while let Ok(Some(event)) = term.poll_input(None) {
+            match self.mode.clone() {
+                Mode::Pick => self.handle_pick_event(event),
+                Mode::Prompt {
+                    domain,
+                    input,
+                    error: _,
+                } => self.handle_prompt_event(event, domain, input),
+            }
+            if matches!(self.mode, Mode::Pick) && self.selection == "__done__" {
+                break;
+            }
+            self.render(term)?;
+        }
+        Ok(())
+    }
+
+    fn handle_pick_event(&mut self, event: InputEvent) {
+        match event {
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char(c),
+                modifiers: Modifiers::NONE,
+            }) if ALPHABET.contains(c) => {
+                self.selection.push(c);
+                if let Some(pos) = self.labels.iter().position(|x| *x == self.selection) {
+                    self.active_idx = self.top_row + pos;
+                    if self.launch(self.active_idx) {
+                        self.selection = "__done__".to_string();
+                    }
+                }
+            }
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('n'),
+                ..
+            }) => {
+                if let Some(entry) = self.entries.get(self.active_idx).cloned() {
+                    if let EntryAction::Manual {
+                        domain,
+                        default_name,
+                    } = entry.action
+                    {
+                        self.mode = Mode::Prompt {
+                            domain,
+                            input: default_name,
+                            error: None,
+                        };
+                    }
+                }
+            }
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('j'),
+                ..
+            })
+            | InputEvent::Key(KeyEvent {
+                key: KeyCode::DownArrow,
+                ..
+            }) => self.move_down(),
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('k'),
+                ..
+            })
+            | InputEvent::Key(KeyEvent {
+                key: KeyCode::UpArrow,
+                ..
+            }) => self.move_up(),
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Enter,
+                ..
+            }) => {
+                if self.launch(self.active_idx) {
+                    self.selection = "__done__".to_string();
+                }
+            }
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Escape,
+                ..
+            })
+            | InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('G') | KeyCode::Char('['),
+                modifiers: Modifiers::CTRL,
+            }) => {
+                self.selection = "__done__".to_string();
+            }
+            InputEvent::Mouse(MouseEvent {
+                y, mouse_buttons, ..
+            }) if mouse_buttons.contains(MouseButtons::VERT_WHEEL) => {
+                if mouse_buttons.contains(MouseButtons::WHEEL_POSITIVE) {
+                    self.top_row = self.top_row.saturating_sub(1);
+                } else {
+                    self.top_row = (self.top_row + 1).min(
+                        self.entries
+                            .len()
+                            .saturating_sub(self.max_items)
+                            .saturating_sub(1),
+                    );
+                }
+                if y > 0 && y as usize <= self.entries.len() {
+                    self.active_idx = self.top_row + y as usize - 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_prompt_event(&mut self, event: InputEvent, domain: String, mut input: String) {
+        match event {
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Escape,
+                ..
+            }) => self.mode = Mode::Pick,
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Backspace,
+                ..
+            }) => {
+                input.pop();
+                self.mode = Mode::Prompt {
+                    domain,
+                    input,
+                    error: None,
+                };
+            }
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Enter,
+                ..
+            }) => match validate_shell_name(&input) {
+                Ok(()) => {
+                    self.open(domain, input);
+                    self.mode = Mode::Pick;
+                    self.selection = "__done__".to_string();
+                }
+                Err(err) => {
+                    self.mode = Mode::Prompt {
+                        domain,
+                        input,
+                        error: Some(err),
+                    }
+                }
+            },
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char(c),
+                ..
+            }) => {
+                input.push(c);
+                self.mode = Mode::Prompt {
+                    domain,
+                    input,
+                    error: None,
+                };
+            }
+            _ => {
+                self.mode = Mode::Prompt {
+                    domain,
+                    input,
+                    error: None,
+                }
+            }
+        }
+    }
+}
+
+fn build_entries(vms: &[D2bVmPickerEntry]) -> Vec<Entry> {
+    let mut entries = vec![];
+    for vm in vms {
+        if !vm.available {
+            entries.push(Entry {
+                label: format!("Unavailable d2b VM `{}` (offline)", vm.vm_name),
+                disabled: true,
+                action: EntryAction::Disabled,
+            });
+            continue;
+        }
+
+        entries.push(Entry {
+            label: format!("New d2b shell on `{}` ({})", vm.vm_name, vm.generated_name),
+            disabled: false,
+            action: EntryAction::Open {
+                domain: vm.domain_name.clone(),
+                name: vm.generated_name.clone(),
+            },
+        });
+        entries.push(Entry {
+            label: format!("Name new d2b shell on `{}`…", vm.vm_name),
+            disabled: false,
+            action: EntryAction::Manual {
+                domain: vm.domain_name.clone(),
+                default_name: vm.generated_name.clone(),
+            },
+        });
+
+        let mut sessions = vm.sessions.clone();
+        sessions.sort_by(|a, b| b.is_default.cmp(&a.is_default).then(a.id.cmp(&b.id)));
+        for session in sessions {
+            let state = if session.is_default {
+                "default".to_string()
+            } else if session.attached {
+                "attached".to_string()
+            } else {
+                format!("{:?}", session.state).to_ascii_lowercase()
+            };
+            entries.push(Entry {
+                label: format!("Open d2b shell `{}:{}` ({state})", vm.vm_name, session.id),
+                disabled: false,
+                action: EntryAction::Open {
+                    domain: vm.domain_name.clone(),
+                    name: session.id,
+                },
+            });
+        }
+    }
+    entries
+}
+
+pub fn d2b_launcher(
+    args: D2bLauncherArgs,
+    mut term: TermWizTerminal,
+    window: ::window::Window,
+) -> anyhow::Result<()> {
+    let mut state = State::new(args, window);
+    term.set_raw_mode()?;
+    term.render(&[Change::Title("d2b sessions".to_string())])?;
+    state.render(&mut term)?;
+    state.run_loop(&mut term)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use mux::d2b::{D2bCorrelationId, ShellSessionState};
+
+    fn session(name: &str, is_default: bool) -> D2bSession {
+        D2bSession {
+            id: name.to_string(),
+            label: name.to_string(),
+            vm_name: "work".to_string(),
+            workspace: None,
+            state: ShellSessionState::Detached,
+            attached: false,
+            is_default,
+            correlation_id: D2bCorrelationId::from_sensitive("session", name),
+        }
+    }
+
+    #[test]
+    fn entries_disable_offline_vms_without_open_actions() {
+        let entries = build_entries(&[D2bVmPickerEntry {
+            domain_name: "d2b-work".to_string(),
+            vm_name: "work".to_string(),
+            available: false,
+            sessions: vec![],
+            generated_name: "work-shell".to_string(),
+        }]);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].disabled);
+        assert_eq!(entries[0].action, EntryAction::Disabled);
+    }
+
+    #[test]
+    fn entries_include_generated_manual_and_existing_sessions() {
+        let entries = build_entries(&[D2bVmPickerEntry {
+            domain_name: "d2b-work".to_string(),
+            vm_name: "work".to_string(),
+            available: true,
+            sessions: vec![session("default", true), session("build", false)],
+            generated_name: "work-shell".to_string(),
+        }]);
+        assert!(entries
+            .iter()
+            .any(|entry| entry.label.contains("work-shell")));
+        assert!(entries
+            .iter()
+            .any(|entry| matches!(entry.action, EntryAction::Manual { .. })));
+        assert!(entries
+            .iter()
+            .any(|entry| entry.label.contains("work:default")));
+        assert!(entries.iter().all(|entry| !entry.disabled));
+    }
+}

--- a/wezterm-gui/src/overlay/d2b_launcher.rs
+++ b/wezterm-gui/src/overlay/d2b_launcher.rs
@@ -1,7 +1,9 @@
 use crate::overlay::quickselect;
 use crate::termwindow::TermWindowNotif;
 use config::keyassignment::KeyAssignment;
-use mux::d2b::{friendly_session_name, validate_shell_name, D2bDomain, D2bSession};
+use mux::d2b::{
+    friendly_session_name, sanitize_display_label, validate_shell_name, D2bDomain, D2bSession,
+};
 use mux::domain::Domain;
 use mux::termwiztermtab::TermWizTerminal;
 use mux::Mux;
@@ -438,9 +440,10 @@ impl State {
 fn build_entries(vms: &[D2bVmPickerEntry]) -> Vec<Entry> {
     let mut entries = vec![];
     for vm in vms {
+        let vm_label = sanitize_display_label(&vm.vm_name);
         if !vm.available {
             entries.push(Entry {
-                label: format!("Unavailable d2b VM `{}` (offline)", vm.vm_name),
+                label: format!("Unavailable d2b VM `{vm_label}` (offline)"),
                 disabled: true,
                 action: EntryAction::Disabled,
             });
@@ -448,7 +451,10 @@ fn build_entries(vms: &[D2bVmPickerEntry]) -> Vec<Entry> {
         }
 
         entries.push(Entry {
-            label: format!("New d2b shell on `{}` ({})", vm.vm_name, vm.generated_name),
+            label: format!(
+                "New d2b shell on `{vm_label}` ({})",
+                sanitize_display_label(&vm.generated_name)
+            ),
             disabled: false,
             action: EntryAction::Open {
                 domain: vm.domain_name.clone(),
@@ -456,7 +462,7 @@ fn build_entries(vms: &[D2bVmPickerEntry]) -> Vec<Entry> {
             },
         });
         entries.push(Entry {
-            label: format!("Name new d2b shell on `{}`…", vm.vm_name),
+            label: format!("Name new d2b shell on `{vm_label}`…"),
             disabled: false,
             action: EntryAction::Manual {
                 domain: vm.domain_name.clone(),
@@ -467,6 +473,7 @@ fn build_entries(vms: &[D2bVmPickerEntry]) -> Vec<Entry> {
         let mut sessions = vm.sessions.clone();
         sessions.sort_by(|a, b| b.is_default.cmp(&a.is_default).then(a.id.cmp(&b.id)));
         for session in sessions {
+            let session_label = sanitize_display_label(&session.id);
             let state = if session.is_default {
                 "default".to_string()
             } else if session.attached {
@@ -475,7 +482,7 @@ fn build_entries(vms: &[D2bVmPickerEntry]) -> Vec<Entry> {
                 format!("{:?}", session.state).to_ascii_lowercase()
             };
             entries.push(Entry {
-                label: format!("Open d2b shell `{}:{}` ({state})", vm.vm_name, session.id),
+                label: format!("Open d2b shell `{vm_label}:{session_label}` ({state})"),
                 disabled: false,
                 action: EntryAction::Open {
                     domain: vm.domain_name.clone(),
@@ -550,5 +557,24 @@ mod test {
             .iter()
             .any(|entry| entry.label.contains("work:default")));
         assert!(entries.iter().all(|entry| !entry.disabled));
+    }
+
+    #[test]
+    fn entries_sanitize_vm_and_session_labels() {
+        let entries = build_entries(&[D2bVmPickerEntry {
+            domain_name: "d2b-work".to_string(),
+            vm_name: "work\x1b[31m".to_string(),
+            available: true,
+            sessions: vec![session("bad\x07\x1b[31m", false)],
+            generated_name: "work-shell".to_string(),
+        }]);
+        let combined = entries
+            .iter()
+            .map(|entry| entry.label.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!combined.contains('\x1b'));
+        assert!(!combined.contains('\x07'));
+        assert!(combined.contains("work:bad"));
     }
 }

--- a/wezterm-gui/src/overlay/mod.rs
+++ b/wezterm-gui/src/overlay/mod.rs
@@ -17,6 +17,8 @@ pub mod selector;
 
 // --- weezterm remote features ---
 pub mod config_overlay;
+#[cfg(target_os = "linux")]
+pub mod d2b_launcher;
 pub mod devcontainer;
 pub mod port_forward;
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -351,6 +351,36 @@ impl UserData for PaneInformation {
     }
 }
 
+// --- weezterm remote features ---
+fn d2b_window_title(
+    active_pane: &PaneInformation,
+    tabs: &[TabInformation],
+    num_tabs: usize,
+) -> Option<String> {
+    let vm = active_pane.user_vars.get("weezterm.d2b.vm")?;
+    let same_vm = tabs
+        .iter()
+        .filter(|tab| {
+            tab.active_pane
+                .as_ref()
+                .and_then(|pane| pane.user_vars.get("weezterm.d2b.vm"))
+                == Some(vm)
+        })
+        .count();
+
+    if same_vm > 1 {
+        Some(format!(
+            "d2b {vm} ({same_vm} sessions) - {}",
+            active_pane.title
+        ))
+    } else if num_tabs == 1 {
+        Some(active_pane.title.clone())
+    } else {
+        None
+    }
+}
+// --- end weezterm remote features ---
+
 #[derive(Default)]
 pub struct TabState {
     /// If is_some(), rather than display the actual tab
@@ -2773,7 +2803,10 @@ impl TermWindow {
             Some(title) => title,
             None => {
                 if let (Some(pos), Some(tab)) = (active_pane, active_tab) {
-                    if num_tabs == 1 {
+                    // --- weezterm remote features ---
+                    if let Some(title) = d2b_window_title(&pos, &tabs, num_tabs) {
+                        title
+                    } else if num_tabs == 1 {
                         format!("{}{}", if pos.is_zoomed { "[Z] " } else { "" }, pos.title)
                     } else {
                         format!(
@@ -2784,6 +2817,7 @@ impl TermWindow {
                             pos.title
                         )
                     }
+                    // --- end weezterm remote features ---
                 } else {
                     "".to_string()
                 }
@@ -3507,6 +3541,63 @@ impl TermWindow {
         .detach();
     }
 
+    // --- weezterm remote features ---
+    #[cfg(target_os = "linux")]
+    fn show_d2b_launcher(&mut self) {
+        let window = self.window.as_ref().unwrap().clone();
+        let mux = Mux::get();
+        let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+            Some(tab) => tab,
+            None => return,
+        };
+        let pane = match self.get_active_pane_or_overlay() {
+            Some(pane) => pane,
+            None => return,
+        };
+        let pane_id = pane.pane_id();
+        let tab_id = tab.tab_id();
+
+        promise::spawn::spawn(async move {
+            let args = crate::overlay::d2b_launcher::D2bLauncherArgs::new(pane_id).await;
+            let win = window.clone();
+            win.notify(TermWindowNotif::Apply(Box::new(move |term_window| {
+                let mux = Mux::get();
+                if let Some(tab) = mux.get_tab(tab_id) {
+                    let window = window.clone();
+                    let (overlay, future) =
+                        start_overlay(term_window, &tab, move |_tab_id, term| {
+                            crate::overlay::d2b_launcher::d2b_launcher(args, term, window)
+                        });
+
+                    term_window.assign_overlay(tab_id, overlay);
+                    promise::spawn::spawn(future).detach();
+                }
+            })));
+        })
+        .detach();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn show_d2b_launcher(&mut self) {
+        log::warn!("native d2b session picker is only supported on Linux");
+    }
+
+    fn open_d2b_session(&mut self, domain: &str, name: Option<&str>) {
+        let mut env = HashMap::new();
+        if let Some(name) = name {
+            env.insert(mux::d2b::D2B_SHELL_NAME_ENV.to_string(), name.to_string());
+        }
+        self.spawn_command(
+            &SpawnCommand {
+                domain: config::keyassignment::SpawnTabDomain::DomainName(domain.to_string()),
+                set_environment_variables: env,
+                ..Default::default()
+            },
+            SpawnWhere::NewTab,
+        );
+    }
+    // --- end weezterm remote features ---
+
     /// Returns the Prompt semantic zones
     fn get_semantic_prompt_zones(&mut self, pane: &Arc<dyn Pane>) -> &[StableRowIndex] {
         let cache = self
@@ -3830,6 +3921,10 @@ impl TermWindow {
                 };
                 self.show_launcher_impl(args, 0);
             }
+            // --- weezterm remote features ---
+            ShowD2bLauncher => self.show_d2b_launcher(),
+            D2bOpenSession { domain, name } => self.open_d2b_session(domain, name.as_deref()),
+            // --- end weezterm remote features ---
             HideApplication => {
                 let con = Connection::get().expect("call on gui thread");
                 con.hide_application();

--- a/wezterm-mux-server-impl/src/lib.rs
+++ b/wezterm-mux-server-impl/src/lib.rs
@@ -90,6 +90,37 @@ fn update_mux_domains_impl(config: &ConfigHandle, is_standalone_mux: bool) -> an
     }
 
     // --- weezterm remote features ---
+    #[cfg(target_os = "linux")]
+    for d2b_dom in &config.d2b_domains {
+        if let Ok(bound_vm) = std::env::var(mux::d2b::D2B_BOUND_VM_ENV) {
+            if bound_vm != d2b_dom.vm.as_str() {
+                continue;
+            }
+        }
+        if mux.get_domain_by_name(&d2b_dom.name).is_some() {
+            continue;
+        }
+
+        let mut runtime = mux::d2b::D2bRuntimeConfig::default();
+        if let Some(socket_path) = &d2b_dom.socket_path {
+            runtime.socket_path = socket_path.clone();
+        }
+        let domain: Arc<dyn Domain> = Arc::new(mux::d2b::native_domain_with_name(
+            d2b_dom.name.clone(),
+            d2b_dom.vm.clone(),
+            runtime,
+        ));
+        mux.add_domain(&domain);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    for d2b_dom in &config.d2b_domains {
+        log::warn!(
+            "Ignoring d2b domain {}: native d2b domains are only supported on Linux",
+            d2b_dom.name
+        );
+    }
+
     for dc_dom in &config.devcontainer_domains {
         if mux.get_domain_by_name(&dc_dom.name).is_some() {
             continue;


### PR DESCRIPTION
## Summary

Add a native Linux d2b shell provider and launcher integration to WeezTerm:

- uses `d2b-client` directly instead of spawning `d2b shell`
- maps pane I/O, resize, close, and detach to d2b-owned shell sessions
- preserves d2b as the shell persistence authority
- adds a d2b session picker with create/open flows and VM/session-aware titles
- isolates VM-bound windows with per-VM mux sockets
- sanitizes launcher/title labels and keeps diagnostics redacted
- packages `d2b-toolkit` as a followable flake input with Nix path rewrites

## Validation

- `nix develop --command bash -lc 'cargo fmt --package mux --package wezterm-gui -- --check && cargo test -p mux d2b --quiet && cargo test -p wezterm-gui d2b_launcher --quiet && git diff --check'`
- `nix eval --impure --no-warn-dirty .#packages.x86_64-linux.default.pname`
