### PR TITLE
Include Wayland runtime libraries in source build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Source-built Nix packages now include Wayland runtime libraries in their
+  binary rpaths, and Wayland-only launches fail with the original Wayland error
+  instead of falling back to X11 and hiding the missing library cause.
 - Nix flake packaging declares `d2b-toolkit` as an input and rewrites native d2b
   client crate paths during builds, avoiding developer-local absolute paths.
 

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -96,6 +96,20 @@
           [
             libxcb-image
             libGL
+            wayland
+            vulkan-loader
+          ]
+        );
+        runtimeLibPath = lib.makeLibraryPath (
+          with pkgs;
+          [
+            libxcb-image
+            libGL
+            libxkbcommon
+            libx11
+            libxcb
+            libxcb-util
+            wayland
             vulkan-loader
           ]
         );
@@ -214,6 +228,14 @@
               mv $out/bin/{weezterm,weezterm-mux-server,weezterm-gui,strip-ansi-escapes} "$OUT_APP"
               ln -s "$OUT_APP"/{weezterm,weezterm-mux-server,weezterm-gui,strip-ansi-escapes} "$out/bin"
             '';
+
+          postFixup = lib.optionalString stdenv.isLinux /* bash */ ''
+            for bin in weezterm weezterm-mux-server weezterm-gui; do
+              if [ -x "$out/bin/$bin" ]; then
+                patchelf --set-rpath "${runtimeLibPath}:$(patchelf --print-rpath "$out/bin/$bin")" "$out/bin/$bin"
+              fi
+            done
+          '';
 
           postInstall = ''
             mkdir -p $out/nix-support

--- a/window/src/os/x_and_wayland.rs
+++ b/window/src/os/x_and_wayland.rs
@@ -46,6 +46,11 @@ impl Connection {
                 }
                 Err(e) => {
                     log::debug!("Failed to init wayland: {}", e);
+                    if std::env::var_os("WAYLAND_DISPLAY").is_some()
+                        && std::env::var_os("DISPLAY").is_none()
+                    {
+                        return Err(e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Patch source-built WeezTerm binaries after fixup so Wayland runtime libraries are present in their rpath. Without this, Wayland-only/proxied launches fail at runtime while trying to dlopen `libwayland-client.so.0`, then fall back to X11 and report `XOpenDisplay failed`.

## Validation

- `nix develop --command bash -lc 'cargo fmt --package window -- --check && cargo check -p window --quiet && git diff --check'`
- `nix build --impure --no-warn-dirty .#packages.x86_64-linux.source -o /tmp/weezterm-rpath-pr`
- `patchelf --print-rpath /tmp/weezterm-rpath-pr/bin/weezterm-gui | grep wayland`
- Private proxied launch no longer reports missing Wayland libraries; strace shows `libwayland-client.so.0` resolves from the Wayland store path.
