### PR TITLE
Use seqpacket transport for native d2b provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Source-built Nix packages now include Wayland runtime libraries in their
   binary rpaths, and Wayland-only launches fail with the original Wayland error
   instead of falling back to X11 and hiding the missing library cause.
+- Native d2b provider connections now use d2bd's SOCK_SEQPACKET public socket
+  transport, preserving frame packet boundaries for shell attach/read/write
+  requests.
 - Nix flake packaging declares `d2b-toolkit` as an input and rewrites native d2b
   client crate paths during builds, avoiding developer-local absolute paths.
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783289531,
-        "narHash": "sha256-oZJ76XrHajbdm3YsRu0qe+PsGZkscDYBjdR0iD4YzY0=",
+        "lastModified": 1783296950,
+        "narHash": "sha256-OdvP+Gnd+WJ4G/egzkwC6Y7ed8CjMH0TNtT8VRet5xI=",
         "owner": "vicondoa",
         "repo": "d2b-toolkit",
-        "rev": "1c359ae97472d91d75113d08ac13a1c153cbe088",
+        "rev": "708db5c6c0c1df56d6232c497c6720c2a07e6cc6",
         "type": "github"
       },
       "original": {

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -28,7 +28,7 @@ luahelper.workspace = true
 metrics.workspace = true
 mlua.workspace = true
 names.workspace = true
-nix = {workspace=true, features=["term"]}
+nix = {workspace=true, features=["socket", "term"]}
 parking_lot.workspace = true
 percent-encoding.workspace = true
 portable-pty = { workspace=true, features = ["serde_support"]}

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -159,7 +159,6 @@ mod imp {
     use crate::{Mux, MuxNotification};
     use anyhow::{anyhow, bail};
     use async_channel::{Receiver, Sender, TrySendError};
-    use async_io::Async;
     use async_trait::async_trait;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine as _;
@@ -168,6 +167,7 @@ mod imp {
         Hello, KnownFeatureFlag, Redacted, ShellName, ShellSessionState, SocketClass,
         TerminalSize as D2bTerminalSize, TerminalStream,
     };
+    use futures::io::{AsyncRead, AsyncWrite};
     use futures::{future, Future};
     use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
     use rangeset::RangeSet;
@@ -178,8 +178,7 @@ mod imp {
     use std::future::Future as StdFuture;
     use std::io::{Error as IoError, ErrorKind, Write};
     use std::ops::Range;
-    use std::os::fd::OwnedFd;
-    use std::os::unix::net::UnixStream;
+    use std::os::fd::{AsRawFd, OwnedFd};
     use std::path::{Path, PathBuf};
     use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -451,7 +450,95 @@ mod imp {
         }
     }
 
-    type D2bSocket = Async<UnixStream>;
+    const MAX_PUBLIC_PACKET: usize = 1024 * 1024 + 4;
+
+    pub struct D2bSocket {
+        fd: OwnedFd,
+        read_buf: Vec<u8>,
+        read_pos: usize,
+        write_buf: Vec<u8>,
+    }
+
+    impl D2bSocket {
+        fn new(fd: OwnedFd) -> Self {
+            Self {
+                fd,
+                read_buf: Vec::new(),
+                read_pos: 0,
+                write_buf: Vec::new(),
+            }
+        }
+    }
+
+    impl AsyncRead for D2bSocket {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut [u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            if self.read_pos >= self.read_buf.len() {
+                let mut packet = vec![0_u8; MAX_PUBLIC_PACKET];
+                let len = nix::sys::socket::recv(
+                    self.fd.as_raw_fd(),
+                    &mut packet,
+                    nix::sys::socket::MsgFlags::empty(),
+                )
+                .map_err(errno_to_io)?;
+                packet.truncate(len);
+                self.read_buf = packet;
+                self.read_pos = 0;
+                if self.read_buf.is_empty() {
+                    return std::task::Poll::Ready(Ok(0));
+                }
+            }
+            let available = &self.read_buf[self.read_pos..];
+            let len = available.len().min(buf.len());
+            buf[..len].copy_from_slice(&available[..len]);
+            self.read_pos += len;
+            std::task::Poll::Ready(Ok(len))
+        }
+    }
+
+    impl AsyncWrite for D2bSocket {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            self.write_buf.extend_from_slice(buf);
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            if !self.write_buf.is_empty() {
+                let sent = nix::sys::socket::send(
+                    self.fd.as_raw_fd(),
+                    &self.write_buf,
+                    nix::sys::socket::MsgFlags::empty(),
+                )
+                .map_err(errno_to_io)?;
+                if sent != self.write_buf.len() {
+                    return std::task::Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "short write on public seqpacket socket",
+                    )));
+                }
+                self.write_buf.clear();
+            }
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            self.poll_flush(cx)
+        }
+    }
+
     type D2bClient = PublicSocketClient<D2bSocket>;
     type D2bShell = AttachedShell<D2bSocket>;
 
@@ -607,30 +694,19 @@ mod imp {
         let sockaddr = SockAddr::unix(path)?;
         let socket = Socket::new(
             SocketDomain::UNIX,
-            Type::from(libc::SOCK_STREAM | libc::SOCK_CLOEXEC),
+            Type::from(libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC),
             None,
         )?;
-        socket.set_nonblocking(true)?;
         match socket.connect(&sockaddr) {
             Ok(()) => {}
-            Err(err) if is_connect_in_progress(&err) => {}
             Err(err) => return Err(err),
         }
         let owned: OwnedFd = socket.into();
-        let stream = UnixStream::from(owned);
-        stream.set_nonblocking(true)?;
-        let stream = Async::new(stream)?;
-        stream.writable().await?;
-        if let Some(err) = stream.get_ref().take_error()? {
-            return Err(err);
-        }
-        Ok(stream)
+        Ok(D2bSocket::new(owned))
     }
 
-    fn is_connect_in_progress(err: &std::io::Error) -> bool {
-        err.kind() == ErrorKind::WouldBlock
-            || err.raw_os_error() == Some(libc::EINPROGRESS)
-            || err.raw_os_error() == Some(libc::EALREADY)
+    fn errno_to_io(error: nix::errno::Errno) -> std::io::Error {
+        std::io::Error::from_raw_os_error(error as i32)
     }
 
     fn classify_socket_path(path: &Path) -> SocketClass {

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783289531,
-        "narHash": "sha256-oZJ76XrHajbdm3YsRu0qe+PsGZkscDYBjdR0iD4YzY0=",
+        "lastModified": 1783296950,
+        "narHash": "sha256-OdvP+Gnd+WJ4G/egzkwC6Y7ed8CjMH0TNtT8VRet5xI=",
         "owner": "vicondoa",
         "repo": "d2b-toolkit",
-        "rev": "1c359ae97472d91d75113d08ac13a1c153cbe088",
+        "rev": "708db5c6c0c1df56d6232c497c6720c2a07e6cc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Use d2bd's SOCK_SEQPACKET public socket transport in the native d2b provider and update toolkit locks to the public-socket protocol fixes.

This preserves packet/frame boundaries for hello, shell attach, read, write, resize, and close operations.

## Validation

- `nix develop --command bash -lc 'cargo fmt --package mux --package window -- --check && cargo check -p mux -p window --quiet && cargo test -p mux d2b --quiet && cargo test -p wezterm-gui d2b_launcher --quiet && git diff --check'`
- `nix build --impure --no-warn-dirty .#packages.x86_64-linux.source -o /tmp/weezterm-provider-final`
- Private proxied launch through d2b-wayland-proxy rendered a Wayland WebGPU window and reached the native d2b provider path.
