### PR TITLE
d2b: read PTY shell output from stdout only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Native d2b shell panes now read from d2b's PTY stdout stream only, matching
+  the persistent-shell wire contract and avoiding false reattach prompts when a
+  separate stderr stream is unavailable.
 - Source-built Nix packages now include Wayland runtime libraries in their
   binary rpaths, and Wayland-only launches fail with the original Wayland error
   instead of falling back to X11 and hiding the missing library cause.

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -859,7 +859,7 @@ mod imp {
                 return;
             }
 
-            for stream in [TerminalStream::Stdout, TerminalStream::Stderr] {
+            for stream in [TerminalStream::Stdout] {
                 match client_op(
                     "reading d2b shell output",
                     Some(correlation_id.clone()),


### PR DESCRIPTION
## Summary
- Read native d2b shell pane output from the PTY stdout stream only.
- Avoid false reattach prompts when d2b persistent shells do not expose a separate stderr stream.
- Add an Unreleased changelog note.

## Validation
- nix build --impure --no-warn-dirty .#packages.x86_64-linux.source
- Private smoke: patched WeezTerm launched through patched d2b-wayland-proxy --host-terminal against d2b-test; no guest-control-shell-error, requires-reattach, TTY_STDERR, missing library, invalid domain, or xdg_surface failure markers; WebGPU surface configured successfully.