### PR TITLE
fix: preserve dynamic d2b titles and scope shell picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ working on this codebase.
 | Test specific crate | `cargo nextest run -p <crate>` |
 | Test escape parser (no_std) | `cargo nextest run -p wezterm-escape-parser` |
 | **UX tests (Windows)** | **`cd tests/ux && pip install -r requirements.txt && python -m pytest -v -s`** |
+| **Title UX (Linux/Wayland)** | **`nix develop .#wayland-title --command bash ./tests/wayland-title/run.sh --target <target>`** |
 | Lint | `cargo clippy` |
 
 ## Project Structure
@@ -406,6 +407,7 @@ git merge upstream/main          # or rebase, per preference
 | Window resize/DPI handling | `wezterm-gui/src/termwindow/resize.rs`, `window/src/os/windows/window.rs` |
 | Window state persistence | `wezterm-gui/src/window_state_persistence.rs` |
 | UX tests (automated) | `tests/ux/` (see UX Testing section below) |
+| Wayland title UX | `tests/wayland-title/` |
 | UX tests (manual) | `tests/ux/MANUAL_TESTS.md` |
 
 ## UX Testing
@@ -451,6 +453,26 @@ Test suites:
   (connects to `jvicondo-a7` with an isolated workspace; requires SSH access)
 
 Failed tests save screenshots to `tests/ux/test-results/` for debugging.
+
+### Linux Wayland title test
+
+`tests/wayland-title/` starts a private headless Weston parent and a dedicated
+nested Niri compositor. It never uses the logged-in desktop, lock screen, or
+host Niri IPC. The test drives a source-built WeezTerm through its private mux
+socket, captures the client-side title bar with `grim`, and checks foreground
+and background OSC title updates across repeated tab switches.
+
+```bash
+cargo build -p wezterm -p wezterm-gui
+nix develop .#wayland-title --command bash \
+  ./tests/wayland-title/run.sh \
+  --target tools.host.d2b \
+  --second-local
+```
+
+Use `--second-local` for providers that intentionally allow only one attached
+shell. See `tests/wayland-title/README.md` for disposable shell names, artifacts,
+and the compositor-only smoke mode.
 
 ### Manual Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A reproducible Linux Wayland title-bar harness using an isolated headless
+  Weston parent and dedicated nested Niri compositor.
+
+### Fixed
+
+- d2b window titles now follow the active tab's latest OSC or explicit title
+  immediately when switching tabs and append the trusted `[target:shell]`
+  identity as a suffix.
+- Wayland client-side title bars now render the current window title instead of
+  showing a blank frame when the compositor does not draw server-side titles.
+- The new-tab dropdown in a d2b-bound window now offers only immediate shell
+  creation and detached shells from the current target; regular windows retain
+  the generic launcher.
+
 ## [0.7.0] - 2026-07-11
 
 ### Added

--- a/docs/d2b-provider.md
+++ b/docs/d2b-provider.md
@@ -104,6 +104,23 @@ domain names, so a target is never used as a filesystem path component.
 - Window-title d2b identity comes from the mux pane's configured d2b domain,
   never terminal-controlled user variables. Compatibility user variables are
   presentation metadata and cannot make a local or SSH pane appear d2b-backed.
+- d2b pane and tab titles append that trusted identity as
+  `application title [target:shell]`. OSC title changes remain dynamic. The
+  native window title follows the active tab's latest title, including updates
+  received while the tab was in the background, and changes immediately when
+  the active tab changes. When space is constrained, WeezTerm truncates the
+  untrusted application portion from the right or left edge as appropriate
+  while preserving the trailing trusted identity.
+- The tab-bar new-tab dropdown is target-scoped when its active pane belongs to
+  a process-bound d2b domain. It offers one immediate generated-shell action and
+  reattachment actions only for detached shells on that target. It never offers
+  attached or unavailable sessions, manual shell naming, local/unmanaged
+  shells, SSH/mux domains, or socket attachment. Non-d2b windows keep the
+  generic new-tab dropdown.
+- A persistent shell has one attachment owner. WeezTerm does not force attach:
+  attached shells are omitted because another attachment would fail or require
+  evicting the current owner. The sole owner supplies the initial terminal size
+  and sends subsequent resize updates.
 
 ## Redaction and diagnostics
 

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -1,6 +1,8 @@
 use d2b_toolkit_core::WorkloadTarget;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+use termwiz::cell::unicode_column_width;
+use termwiz_funcs::{truncate_left, truncate_right};
 
 pub use d2b_toolkit_core::{
     IsolationPosture, KnownFeatureFlag, ShellSessionState, WorkloadAvailability,
@@ -123,12 +125,46 @@ pub fn friendly_session_name(target: &str, existing: &[String]) -> String {
 pub fn d2b_tab_title(target: &str, session: &str, guest_osc_title: &str) -> String {
     let target = sanitize_display_label(target);
     let session = sanitize_display_label(session);
-    let prefix = format!("[{target}:{session}]");
+    let suffix = format!("[{target}:{session}]");
     let guest_osc_title = sanitize_display_text(guest_osc_title);
     if guest_osc_title.is_empty() || guest_osc_title == "wezterm" {
-        prefix
+        suffix
+    } else if guest_osc_title == suffix || guest_osc_title.ends_with(&format!(" {suffix}")) {
+        guest_osc_title
     } else {
-        format!("{prefix} {guest_osc_title}")
+        format!("{guest_osc_title} {suffix}")
+    }
+}
+
+pub fn d2b_tab_title_for_width(
+    target: &str,
+    session: &str,
+    guest_osc_title: &str,
+    max_width: usize,
+) -> String {
+    let target = sanitize_display_label(target);
+    let session = sanitize_display_label(session);
+    let suffix = format!("[{target}:{session}]");
+    let suffix_width = unicode_column_width(&suffix, None);
+    if max_width <= suffix_width {
+        return truncate_left(&suffix, max_width);
+    }
+
+    let guest_osc_title = sanitize_display_text(guest_osc_title);
+    if guest_osc_title.is_empty() || guest_osc_title == "wezterm" || guest_osc_title == suffix {
+        return suffix;
+    }
+
+    let suffix_marker = format!(" {suffix}");
+    let guest_osc_title = guest_osc_title
+        .strip_suffix(&suffix_marker)
+        .unwrap_or(&guest_osc_title);
+    let guest_width = max_width - suffix_width - 1;
+    let guest_osc_title = truncate_right(guest_osc_title, guest_width);
+    if guest_osc_title.is_empty() {
+        suffix
+    } else {
+        format!("{guest_osc_title} {suffix}")
     }
 }
 
@@ -277,7 +313,8 @@ mod imp {
     use url::Url;
     use wezterm_term::color::ColorPalette;
     use wezterm_term::{
-        KeyCode, KeyModifiers, MouseEvent, StableRowIndex, TerminalConfiguration, TerminalSize,
+        Alert, AlertHandler, KeyCode, KeyModifiers, MouseEvent, StableRowIndex,
+        TerminalConfiguration, TerminalSize,
     };
 
     const DEFAULT_SOCKET: &str = "/run/d2b/public.sock";
@@ -1685,6 +1722,28 @@ mod imp {
         detached: AtomicBool,
     }
 
+    struct D2bPaneNotifHandler {
+        pane_id: PaneId,
+    }
+
+    impl AlertHandler for D2bPaneNotifHandler {
+        fn alert(&mut self, alert: Alert) {
+            let pane_id = self.pane_id;
+            promise::spawn::spawn_into_main_thread(async move {
+                let mux = Mux::get();
+                if let Alert::TabTitleChanged(title) = &alert {
+                    if let Some((_domain, _window_id, tab_id)) = mux.resolve_pane_id(pane_id) {
+                        if let Some(tab) = mux.get_tab(tab_id) {
+                            tab.set_title(title.as_deref().unwrap_or(""));
+                        }
+                    }
+                }
+                mux.notify(MuxNotification::Alert { pane_id, alert });
+            })
+            .detach();
+        }
+    }
+
     impl D2bPane {
         pub fn new(
             domain_id: DomainId,
@@ -1692,7 +1751,7 @@ mod imp {
             attached: D2bAttachedPane,
         ) -> Arc<Self> {
             let pane_id = alloc_pane_id();
-            let terminal = wezterm_term::Terminal::new(
+            let mut terminal = wezterm_term::Terminal::new(
                 size,
                 Arc::new(config::TermConfig::new()),
                 config::branding::APP_NAME_DISPLAY,
@@ -1702,6 +1761,7 @@ mod imp {
                     correlation_id: attached.handle.correlation_id.clone(),
                 }),
             );
+            terminal.set_notification_handler(Box::new(D2bPaneNotifHandler { pane_id }));
 
             let pane = Arc::new(Self {
                 pane_id,
@@ -1867,6 +1927,14 @@ mod imp {
 
         fn trusted_d2b_target(&self) -> Option<&str> {
             Some(&self.handle.target)
+        }
+
+        fn trusted_d2b_session(&self) -> Option<&str> {
+            Some(&self.handle.session_id)
+        }
+
+        fn d2b_guest_title(&self) -> Option<String> {
+            Some(self.terminal.lock().get_title().to_string())
         }
 
         fn can_close_without_prompting(&self, _reason: CloseReason) -> bool {
@@ -2558,23 +2626,48 @@ mod imp {
         }
 
         #[test]
-        fn d2b_title_format_prefixes_target_and_session() {
+        fn d2b_title_format_suffixes_target_and_session_once() {
             assert_eq!(
                 super::super::d2b_tab_title("work", "build", ""),
                 "[work:build]"
             );
             assert_eq!(
                 super::super::d2b_tab_title("work", "build", "nvim"),
-                "[work:build] nvim"
+                "nvim [work:build]"
             );
             assert_eq!(
                 super::super::d2b_tab_title("work", "build", "wezterm"),
                 "[work:build]"
             );
             assert_eq!(
-                super::super::d2b_tab_title("work\x1b[31m", "\x07", "nvim\x1b]0;secret\x07"),
-                "[work:unnamed] nvim"
+                super::super::d2b_tab_title("work", "build", "nvim [work:build]"),
+                "nvim [work:build]"
             );
+            assert_eq!(
+                super::super::d2b_tab_title("work\x1b[31m", "\x07", "nvim\x1b]0;secret\x07"),
+                "nvim [work:unnamed]"
+            );
+        }
+
+        #[test]
+        fn d2b_title_width_truncates_only_the_untrusted_guest_title() {
+            let title = super::super::d2b_tab_title_for_width(
+                "work",
+                "build",
+                "[fake:admin] malicious title padded to hide identity",
+                28,
+            );
+            assert!(title.ends_with(" [work:build]"), "{title}");
+            assert!(termwiz::cell::unicode_column_width(&title, None) <= 28);
+
+            let repeated = super::super::d2b_tab_title_for_width(
+                "work",
+                "build",
+                "[fake:admin] padded [work:build]",
+                20,
+            );
+            assert!(repeated.ends_with(" [work:build]"), "{repeated}");
+            assert_eq!(repeated.matches("[work:build]").count(), 1);
         }
 
         #[test]
@@ -2710,6 +2803,7 @@ mod imp {
             );
             assert_eq!(pane.get_title(), "[tools.host.d2b:session-1]");
             assert_eq!(pane.trusted_d2b_target(), Some("tools.host.d2b"));
+            assert_eq!(pane.trusted_d2b_session(), Some("session-1"));
 
             let first = D2bCorrelationId::from_target_session(
                 "attached-shell",

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -254,9 +254,19 @@ pub trait Pane: Downcast + Send + Sync {
     fn palette(&self) -> ColorPalette;
     fn domain_id(&self) -> DomainId;
 
+    // --- weezterm remote features ---
     fn trusted_d2b_target(&self) -> Option<&str> {
         None
     }
+
+    fn trusted_d2b_session(&self) -> Option<&str> {
+        None
+    }
+
+    fn d2b_guest_title(&self) -> Option<String> {
+        None
+    }
+    // --- end weezterm remote features ---
 
     fn get_keyboard_encoding(&self) -> KeyboardEncoding {
         KeyboardEncoding::Xterm

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -115,6 +115,40 @@
           rustc = pkgs.rust-bin.stable."1.96.0".minimal;
         };
 
+        # --- weezterm remote features ---
+        waylandTitleTools = with pkgs; [
+          coreutils
+          findutils
+          grim
+          imagemagick
+          jq
+          niri
+          gnugrep
+          gnused
+          shellcheck
+          tesseract
+          weston
+        ];
+        waylandTitleLibPath = lib.makeLibraryPath [ pkgs.mesa ] + ":${runtimeLibPath}";
+        waylandTitleEglVendor = "${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json";
+        waylandTitleTest =
+          if stdenv.isLinux then
+            pkgs.writeShellApplication {
+              name = "niri-title-test";
+              runtimeInputs = waylandTitleTools;
+              text = ''
+                export WEEZTERM_TITLE_REPO_ROOT="''${WEEZTERM_TITLE_REPO_ROOT:-$PWD}"
+                export WEEZTERM_TITLE_NIRI_CONFIG=${../tests/wayland-title/niri.kdl}
+                export LD_LIBRARY_PATH="${waylandTitleLibPath}:''${LD_LIBRARY_PATH:-}"
+                export __EGL_VENDOR_LIBRARY_FILENAMES="${waylandTitleEglVendor}"
+                export LIBGL_DRIVERS_PATH="${pkgs.mesa}/lib/dri"
+                exec ${../tests/wayland-title/run.sh} "$@"
+              '';
+            }
+          else
+            null;
+        # --- end weezterm remote features ---
+
         prebuiltManifest = builtins.fromJSON (builtins.readFile ./prebuilt.json);
         hasPrebuilt =
           prebuiltManifest.version != null
@@ -324,9 +358,17 @@
         packages.source = sourcePackage;
 
         # --- weezterm remote features ---
-        apps.default = {
-          type = "app";
-          program = "${self.packages.${system}.default}/bin/weezterm";
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/weezterm";
+          };
+        }
+        // lib.optionalAttrs stdenv.isLinux {
+          niri-title-test = {
+            type = "app";
+            program = "${waylandTitleTest}/bin/niri-title-test";
+          };
         };
         # --- end weezterm remote features ---
 
@@ -351,7 +393,18 @@
         };
 
         # --- weezterm remote features ---
-        devShells.default = self.devShell.${system};
+        devShells = {
+          default = self.devShell.${system};
+        }
+        // lib.optionalAttrs stdenv.isLinux {
+          wayland-title = pkgs.mkShell {
+            packages = waylandTitleTools;
+            LD_LIBRARY_PATH = waylandTitleLibPath;
+            __EGL_VENDOR_LIBRARY_FILENAMES = waylandTitleEglVendor;
+            LIBGL_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
+          };
+        };
+        # --- end weezterm remote features ---
 
         formatter = pkgs.nixfmt-rfc-style;
       }

--- a/tests/wayland-title/.gitignore
+++ b/tests/wayland-title/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/tests/wayland-title/README.md
+++ b/tests/wayland-title/README.md
@@ -1,0 +1,117 @@
+# Isolated Wayland title-bar UX harness
+
+This harness starts a private compositor stack:
+
+1. a fresh mode-`0700` `XDG_RUNTIME_DIR`;
+2. headless Weston at `1400x900`;
+3. nested Niri (including 26.04) using its automatically selected winit backend;
+4. source-built WeezTerm with Wayland client-side decorations.
+
+It never connects to the logged-in Wayland/X11 desktop, desktop D-Bus, Niri IPC,
+or lock screen. Niri does not draw window titles. The title visible in each
+captured PNG is WezTerm's client-side title bar and is therefore the UX evidence;
+Niri window metadata is not used as proof.
+
+The harness creates a private `wt-title.*` directory under the caller's user
+runtime directory. Set `WEEZTERM_TITLE_RUNTIME_PARENT` to another short,
+user-writable runtime parent in CI; the resulting path must remain short enough
+for Unix domain sockets.
+
+Weston's fixed `1400x900` headless output and kiosk shell deterministically size
+the nested Niri output to the same dimensions. The minimal Niri fixture disables
+animations and defines no startup applications or title-based window rules.
+
+## Run
+
+Build the source binaries first:
+
+```console
+cargo build -p wezterm -p wezterm-gui
+```
+
+Use the pinned Linux tools and source-binary runtime libraries exposed by the
+root flake:
+
+```console
+nix develop .#wayland-title --command ./tests/wayland-title/run.sh --smoke
+nix develop .#wayland-title --command ./tests/wayland-title/run.sh \
+  --target tools.host.d2b
+```
+
+`nix run .#niri-title-test -- --smoke` is also available for compositor-only
+validation. Use the development shell for a live source build so the untracked
+Cargo binaries remain directly accessible.
+
+The live d2b run requires the target to be disposable and reachable through
+`/run/d2b/public.sock`. Override all relevant inputs when needed:
+
+```console
+nix develop .#wayland-title --command ./tests/wayland-title/run.sh \
+  --target tools.host.d2b \
+  --domain title-test \
+  --shell-one title-a-123 \
+  --shell-two title-b-123 \
+  --d2b-socket /run/d2b/public.sock \
+  --weezterm-bin "$PWD/target/debug/weezterm" \
+  --weezterm-gui-bin "$PWD/target/debug/weezterm-gui" \
+  --artifact-dir "$PWD/tests/wayland-title/results/manual"
+```
+
+Shell names are validated against WezTerm's safe 1-64 byte ASCII form. Defaults
+include the harness PID to avoid reusing another run's persistent d2b sessions.
+The harness closes its attachments but intentionally does not kill persistent
+d2b shells; use caller-supplied disposable names if the daemon retains sessions.
+
+Targets that intentionally permit only one simultaneous attachment can use
+`--second-local`. The first tab remains a real process-bound d2b pane and proves
+the trusted suffix. The second tab is an isolated local fixture used to prove
+background OSC retention and immediate active-tab title switching without
+forcing or evicting the d2b attachment:
+
+```console
+nix develop .#wayland-title --command ./tests/wayland-title/run.sh \
+  --target tools.host.d2b --second-local
+```
+
+Without Nix, provide `weston`, `niri`, `grim`, `jq`, ImageMagick (`magick` and
+`identify`), Tesseract, and standard GNU utilities on `PATH`.
+
+## What the full run proves
+
+The generated Lua config sets `enable_wayland = true` and
+`window_decorations = 'TITLE | RESIZE'`. A `gui-startup` callback uses
+`wezterm.mux.spawn_window` and `window:spawn_tab` with the configured d2b domain
+and `WEEZTERM_D2B_SHELL_NAME`, producing two tabs in one window. Both
+`WEEZTERM_D2B_BOUND_TARGET` and its compatibility alias
+`WEEZTERM_D2B_BOUND_VM` bind the process to the caller's target.
+
+The script discovers the sole private `gui-sock-d2b-*`, pins every
+`weezterm cli` call to it, and uses the repository-verified commands
+`list --format json`, `send-text --pane-id`, and
+`activate-tab --tab-id`. It sets deterministic OSC 0 titles, updates the
+background tab, and captures this sequence without desktop input automation:
+
+- first tab active with its latest title;
+- updated second tab immediately after activation;
+- first tab again;
+- second tab again.
+- a long untrusted background title activated with the trailing trusted d2b
+  identity still visible.
+
+Each state has a full screenshot, an upscaled title crop, raw/normalized OCR,
+and the expected visible `title [target:shell]`. OCR failure fails the run.
+Generated PNGs are compressed and checked to remain below 5 MB.
+
+## Artifacts and failures
+
+The default artifact directory is `tests/wayland-title/results/run-*`; `results/`
+and private runtime directories are gitignored. Logs are retained for Weston,
+Niri, WezTerm, CLI calls, validation, and Tesseract. Socket and process waits are
+bounded. Errors point to the partial artifact directory, while the cleanup trap
+terminates only recorded PIDs and removes only the harness-owned runtime.
+
+Use `--smoke` when no disposable d2b target is available. It validates the Niri
+fixture, private Weston/Niri sockets, compositor liveness, and `grim` capture.
+Common failures are a missing source build, inaccessible d2b socket/target,
+retained shell-name collision, software-rendering support, or OCR failing to
+recognize the client-side title crop.

--- a/tests/wayland-title/niri.kdl
+++ b/tests/wayland-title/niri.kdl
@@ -1,0 +1,16 @@
+hotkey-overlay {
+    skip-at-startup
+}
+
+animations {
+    off
+}
+
+layout {
+    gaps 0
+    center-focused-column "never"
+
+    default-column-width {
+        proportion 1.0
+    }
+}

--- a/tests/wayland-title/run.sh
+++ b/tests/wayland-title/run.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="${WEEZTERM_TITLE_REPO_ROOT:-$(cd -- "$SCRIPT_DIR/../.." && pwd -P)}"
+HARNESS_WORK_DIR="$REPO_ROOT/tests/wayland-title"
+NIRI_CONFIG="${WEEZTERM_TITLE_NIRI_CONFIG:-$SCRIPT_DIR/niri.kdl}"
+
+SMOKE=0
+ARTIFACT_DIR=""
+WEZTERM_BIN="$REPO_ROOT/target/debug/weezterm"
+WEZTERM_GUI_BIN="$REPO_ROOT/target/debug/weezterm-gui"
+TARGET=""
+DOMAIN="title-test"
+D2B_SOCKET="/run/d2b/public.sock"
+SHELL_ONE=""
+SHELL_TWO=""
+SECOND_LOCAL=0
+READY_TIMEOUT=20
+TITLE_TIMEOUT=15
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run.sh --smoke [options]
+  run.sh --target TARGET [options]
+
+Options:
+  --artifact-dir DIR       Result directory (default: results/run-TIMESTAMP-PID)
+  --weezterm-bin PATH      Source-built weezterm CLI
+  --weezterm-gui-bin PATH  Source-built weezterm-gui
+  --target TARGET          d2b target (required outside --smoke)
+  --domain NAME            Generated d2b domain name (default: title-test)
+  --d2b-socket PATH        d2b public socket (default: /run/d2b/public.sock)
+  --shell-one NAME         Disposable first shell session name
+  --shell-two NAME         Disposable second shell session name
+  --second-local           Use a local second tab for single-attachment targets
+  --ready-timeout SECONDS  Process/socket readiness timeout (default: 20)
+  --title-timeout SECONDS  Per-title screenshot/OCR timeout (default: 15)
+  --smoke                  Validate isolated Weston, Niri, and grim only
+  -h, --help               Show this help
+EOF
+}
+
+die() {
+  printf 'wayland-title: error: %s\n' "$*" >&2
+  if [[ -n "$ARTIFACT_DIR" ]]; then
+    printf 'wayland-title: logs and partial artifacts: %s\n' "$ARTIFACT_DIR" >&2
+  fi
+  exit 1
+}
+
+while (($#)); do
+  case "$1" in
+    --artifact-dir)
+      (($# >= 2)) || die "--artifact-dir requires a value"
+      ARTIFACT_DIR=$2
+      shift 2
+      ;;
+    --weezterm-bin|--wezterm-bin)
+      (($# >= 2)) || die "--weezterm-bin requires a value"
+      WEZTERM_BIN=$2
+      shift 2
+      ;;
+    --weezterm-gui-bin|--wezterm-gui-bin)
+      (($# >= 2)) || die "--weezterm-gui-bin requires a value"
+      WEZTERM_GUI_BIN=$2
+      shift 2
+      ;;
+    --target)
+      (($# >= 2)) || die "--target requires a value"
+      TARGET=$2
+      shift 2
+      ;;
+    --domain)
+      (($# >= 2)) || die "--domain requires a value"
+      DOMAIN=$2
+      shift 2
+      ;;
+    --d2b-socket)
+      (($# >= 2)) || die "--d2b-socket requires a value"
+      D2B_SOCKET=$2
+      shift 2
+      ;;
+    --shell-one)
+      (($# >= 2)) || die "--shell-one requires a value"
+      SHELL_ONE=$2
+      shift 2
+      ;;
+    --shell-two)
+      (($# >= 2)) || die "--shell-two requires a value"
+      SHELL_TWO=$2
+      shift 2
+      ;;
+    --second-local)
+      SECOND_LOCAL=1
+      shift
+      ;;
+    --ready-timeout)
+      (($# >= 2)) || die "--ready-timeout requires a value"
+      READY_TIMEOUT=$2
+      shift 2
+      ;;
+    --title-timeout)
+      (($# >= 2)) || die "--title-timeout requires a value"
+      TITLE_TIMEOUT=$2
+      shift 2
+      ;;
+    --smoke)
+      SMOKE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ "$READY_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || die "--ready-timeout must be a positive integer"
+[[ "$TITLE_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || die "--title-timeout must be a positive integer"
+
+if [[ -z "$ARTIFACT_DIR" ]]; then
+  ARTIFACT_DIR="$HARNESS_WORK_DIR/results/run-$(date +%Y%m%d-%H%M%S)-$$"
+fi
+mkdir -p -- "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd -- "$ARTIFACT_DIR" && pwd -P)"
+umask 077
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command '$1'; use nix run .#niri-title-test"
+}
+
+for command in weston niri grim magick identify find stat; do
+  require_command "$command"
+done
+if ((SMOKE == 0)); then
+  for command in jq tesseract; do
+    require_command "$command"
+  done
+fi
+
+[[ -f "$NIRI_CONFIG" ]] || die "missing Niri fixture: $NIRI_CONFIG"
+niri validate -c "$NIRI_CONFIG" >"$ARTIFACT_DIR/niri-validate.log" 2>&1 ||
+  die "Niri rejected $NIRI_CONFIG; see niri-validate.log"
+
+validate_shell_name() {
+  local name=$1
+  ((${#name} >= 1 && ${#name} <= 64)) &&
+    [[ "$name" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]
+}
+
+if ((SMOKE == 0)); then
+  [[ -n "$TARGET" ]] || die "--target is required outside --smoke"
+  [[ "$TARGET" =~ ^[a-z][a-z0-9.-]*$ ]] || die "target must use lowercase [a-z0-9.-] labels"
+  [[ "$TARGET" != *..* ]] || die "target must not contain consecutive dots"
+  [[ "$DOMAIN" =~ ^[A-Za-z0-9_.-]+$ ]] || die "domain must use only [A-Za-z0-9_.-]"
+  [[ -S "$D2B_SOCKET" ]] || die "d2b public socket is not live: $D2B_SOCKET"
+  [[ -x "$WEZTERM_BIN" ]] ||
+    die "source-built weezterm CLI is not executable: $WEZTERM_BIN ($(stat -c '%A %U:%G' "$WEZTERM_BIN" 2>/dev/null || printf 'missing'))"
+  [[ -x "$WEZTERM_GUI_BIN" ]] ||
+    die "source-built weezterm-gui is not executable: $WEZTERM_GUI_BIN ($(stat -c '%A %U:%G' "$WEZTERM_GUI_BIN" 2>/dev/null || printf 'missing'))"
+
+  SHELL_ONE=${SHELL_ONE:-"title-a-$$"}
+  SHELL_TWO=${SHELL_TWO:-"title-b-$$"}
+  validate_shell_name "$SHELL_ONE" || die "invalid --shell-one; use 1-64 safe ASCII shell-name characters"
+  validate_shell_name "$SHELL_TWO" || die "invalid --shell-two; use 1-64 safe ASCII shell-name characters"
+  [[ "$SHELL_ONE" != "$SHELL_TWO" ]] || die "shell names must differ"
+fi
+
+INHERITED_RUNTIME=${XDG_RUNTIME_DIR-}
+INHERITED_WAYLAND=${WAYLAND_DISPLAY-}
+INHERITED_WAYLAND_PATH=""
+if [[ -n "$INHERITED_RUNTIME" && -n "$INHERITED_WAYLAND" && "$INHERITED_WAYLAND" != /* ]]; then
+  INHERITED_WAYLAND_PATH="$INHERITED_RUNTIME/$INHERITED_WAYLAND"
+elif [[ "$INHERITED_WAYLAND" == /* ]]; then
+  INHERITED_WAYLAND_PATH=$INHERITED_WAYLAND
+fi
+
+for variable in WAYLAND_DISPLAY WAYLAND_SOCKET NIRI_SOCKET DISPLAY \
+  DBUS_SESSION_BUS_ADDRESS DBUS_STARTER_ADDRESS DBUS_STARTER_BUS_TYPE \
+  DESKTOP_SESSION XDG_CURRENT_DESKTOP XDG_SESSION_DESKTOP; do
+  unset "$variable"
+done
+while IFS='=' read -r variable _; do
+  [[ "$variable" == DBUS_* ]] && unset "$variable"
+done < <(env)
+
+[[ -d "$HARNESS_WORK_DIR" ]] || die "harness work directory does not exist: $HARNESS_WORK_DIR"
+RUNTIME_PARENT="${WEEZTERM_TITLE_RUNTIME_PARENT:-${INHERITED_RUNTIME:-/run/user/$UID}}"
+[[ -d "$RUNTIME_PARENT" ]] || die "temporary directory does not exist: $RUNTIME_PARENT"
+RUNTIME_DIR=$(mktemp -d "$RUNTIME_PARENT/wt-title.XXXXXXXX")
+chmod 0700 -- "$RUNTIME_DIR"
+export XDG_RUNTIME_DIR="$RUNTIME_DIR"
+export LIBGL_ALWAYS_SOFTWARE=1
+[[ "$(stat -c '%a' "$RUNTIME_DIR")" == 700 ]] || die "private runtime is not mode 0700"
+[[ "$RUNTIME_DIR" != "$INHERITED_RUNTIME" ]] || die "private runtime equals inherited XDG_RUNTIME_DIR"
+
+WESTON_PID=""
+NIRI_PID=""
+WEZTERM_PID=""
+
+terminate_pid() {
+  local pid=$1
+  local label=$2
+  [[ -n "$pid" ]] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    local deadline=$((SECONDS + 3))
+    while kill -0 "$pid" 2>/dev/null && ((SECONDS < deadline)); do
+      sleep 0.05
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      printf 'wayland-title: %s PID %s did not exit after TERM; sending KILL\n' "$label" "$pid" >&2
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  fi
+  wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  terminate_pid "$WEZTERM_PID" "WezTerm"
+  terminate_pid "$NIRI_PID" "Niri"
+  terminate_pid "$WESTON_PID" "Weston"
+  if [[ -n "${RUNTIME_DIR-}" && "$RUNTIME_DIR" == "$RUNTIME_PARENT"/wt-title.* ]]; then
+    rm -rf -- "$RUNTIME_DIR"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+process_alive() {
+  kill -0 "$1" 2>/dev/null
+}
+
+wait_for_socket() {
+  local socket=$1
+  local pid=$2
+  local label=$3
+  local deadline=$((SECONDS + READY_TIMEOUT))
+  while [[ ! -S "$socket" ]]; do
+    process_alive "$pid" || die "$label exited before creating $socket"
+    ((SECONDS < deadline)) || die "timed out waiting for $label socket: $socket"
+    sleep 0.05
+  done
+}
+
+find_one_socket() {
+  local pattern=$1
+  local excluded=${2-}
+  local -a sockets=()
+  while IFS= read -r -d '' socket; do
+    [[ -n "$excluded" && "$socket" == "$excluded" ]] || sockets+=("$socket")
+  done < <(find "$RUNTIME_DIR" -maxdepth 2 -type s -name "$pattern" -print0)
+  ((${#sockets[@]} == 1)) || return 1
+  printf '%s\n' "${sockets[0]}"
+}
+
+wait_for_discovered_socket() {
+  local pattern=$1
+  local excluded=$2
+  local pid=$3
+  local label=$4
+  local deadline=$((SECONDS + READY_TIMEOUT))
+  local socket=""
+  while ! socket=$(find_one_socket "$pattern" "$excluded"); do
+    process_alive "$pid" || die "$label exited before its socket was ready"
+    ((SECONDS < deadline)) || die "timed out waiting for exactly one $label socket matching $pattern"
+    sleep 0.05
+  done
+  printf '%s\n' "$socket"
+}
+
+assert_private_socket() {
+  local socket=$1
+  local label=$2
+  [[ -S "$socket" ]] || die "$label is not a live socket: $socket"
+  case "$(realpath -m -- "$socket")" in
+    "$RUNTIME_DIR"/*) ;;
+    *) die "$label escaped private runtime: $socket" ;;
+  esac
+  if [[ -n "$INHERITED_WAYLAND_PATH" ]]; then
+    [[ "$(realpath -m -- "$socket")" != "$(realpath -m -- "$INHERITED_WAYLAND_PATH")" ]] ||
+      die "$label resolves to the inherited desktop socket"
+  fi
+}
+
+WESTON_SOCKET_NAME="weston-title-test"
+WESTON_SOCKET="$RUNTIME_DIR/$WESTON_SOCKET_NAME"
+weston \
+  --backend=headless-backend.so \
+  --shell=kiosk-shell.so \
+  --renderer=gl \
+  --width=1400 \
+  --height=900 \
+  --idle-time=0 \
+  --socket="$WESTON_SOCKET_NAME" \
+  --log="$ARTIFACT_DIR/weston.log" \
+  >>"$ARTIFACT_DIR/weston.log" 2>&1 &
+WESTON_PID=$!
+wait_for_socket "$WESTON_SOCKET" "$WESTON_PID" "Weston"
+assert_private_socket "$WESTON_SOCKET" "Weston socket"
+
+WAYLAND_DISPLAY="$WESTON_SOCKET_NAME" niri -c "$NIRI_CONFIG" \
+  >"$ARTIFACT_DIR/niri.log" 2>&1 &
+NIRI_PID=$!
+
+NIRI_WAYLAND_SOCKET=$(wait_for_discovered_socket "wayland-*" "$WESTON_SOCKET" "$NIRI_PID" "Niri Wayland")
+NIRI_IPC_SOCKET=$(wait_for_discovered_socket "niri.*.sock" "" "$NIRI_PID" "Niri IPC")
+assert_private_socket "$NIRI_WAYLAND_SOCKET" "Niri Wayland socket"
+assert_private_socket "$NIRI_IPC_SOCKET" "Niri IPC socket"
+
+export WAYLAND_DISPLAY="${NIRI_WAYLAND_SOCKET##*/}"
+export NIRI_SOCKET="$NIRI_IPC_SOCKET"
+[[ "$WAYLAND_DISPLAY" != "$INHERITED_WAYLAND" || "$RUNTIME_DIR" != "$INHERITED_RUNTIME" ]] ||
+  die "nested Niri display was not isolated from the inherited desktop"
+
+capture_plain() {
+  local name=$1
+  local raw="$RUNTIME_DIR/$name-raw.png"
+  local output="$ARTIFACT_DIR/$name.png"
+  WAYLAND_DISPLAY="$WAYLAND_DISPLAY" grim "$raw"
+  magick "$raw" -strip -define png:compression-level=9 "$output"
+  local bytes
+  bytes=$(stat -c '%s' "$output")
+  ((bytes < 5 * 1024 * 1024)) || die "$output is $bytes bytes; expected less than 5 MB"
+}
+
+capture_plain "00-smoke"
+{
+  printf 'private_runtime=%s\n' "$RUNTIME_DIR"
+  printf 'weston_socket=%s\n' "$WESTON_SOCKET"
+  printf 'niri_wayland_socket=%s\n' "$NIRI_WAYLAND_SOCKET"
+  printf 'niri_ipc_socket=%s\n' "$NIRI_IPC_SOCKET"
+} >"$ARTIFACT_DIR/isolation.txt"
+
+if ((SMOKE == 1)); then
+  printf 'wayland-title: smoke passed; artifacts: %s\n' "$ARTIFACT_DIR"
+  exit 0
+fi
+
+WEZTERM_CONFIG="$RUNTIME_DIR/wezterm.lua"
+cat >"$WEZTERM_CONFIG" <<'EOF'
+local wezterm = require 'wezterm'
+local mux = wezterm.mux
+local config = wezterm.config_builder()
+
+local domain = assert(os.getenv('WEEZTERM_TITLE_TEST_DOMAIN'))
+local target = assert(os.getenv('WEEZTERM_TITLE_TEST_TARGET'))
+local socket_path = assert(os.getenv('WEEZTERM_TITLE_TEST_D2B_SOCKET'))
+local shell_one = assert(os.getenv('WEEZTERM_TITLE_TEST_SHELL_ONE'))
+local shell_two = assert(os.getenv('WEEZTERM_TITLE_TEST_SHELL_TWO'))
+local second_local = os.getenv('WEEZTERM_TITLE_TEST_SECOND_LOCAL') == '1'
+
+config.enable_wayland = true
+config.front_end = 'Software'
+config.window_decorations = 'TITLE | RESIZE'
+config.enable_tab_bar = false
+config.initial_cols = 110
+config.initial_rows = 32
+config.font_size = 14.0
+config.automatically_reload_config = false
+config.check_for_updates = false
+config.window_frame = {
+  font_size = 17.0,
+  active_titlebar_bg = '#101010',
+  active_titlebar_fg = '#ffffff',
+  inactive_titlebar_bg = '#101010',
+  inactive_titlebar_fg = '#ffffff',
+}
+config.d2b_domains = {
+  {
+    name = domain,
+    target = target,
+    socket_path = socket_path,
+  },
+}
+config.default_domain = domain
+
+wezterm.on('gui-startup', function()
+  local first_tab, _, window = mux.spawn_window {
+    domain = { DomainName = domain },
+    set_environment_variables = {
+      WEEZTERM_D2B_SHELL_NAME = shell_one,
+    },
+  }
+  if second_local then
+    window:spawn_tab {
+      domain = { DomainName = 'local' },
+    }
+  else
+    window:spawn_tab {
+      domain = { DomainName = domain },
+      set_environment_variables = {
+        WEEZTERM_D2B_SHELL_NAME = shell_two,
+      },
+    }
+  end
+  first_tab:activate()
+end)
+
+return config
+EOF
+cp -- "$WEZTERM_CONFIG" "$ARTIFACT_DIR/wezterm.lua"
+
+export WEEZTERM_TITLE_TEST_DOMAIN="$DOMAIN"
+export WEEZTERM_TITLE_TEST_TARGET="$TARGET"
+export WEEZTERM_TITLE_TEST_D2B_SOCKET="$D2B_SOCKET"
+export WEEZTERM_TITLE_TEST_SHELL_ONE="$SHELL_ONE"
+export WEEZTERM_TITLE_TEST_SHELL_TWO="$SHELL_TWO"
+export WEEZTERM_TITLE_TEST_SECOND_LOCAL="$SECOND_LOCAL"
+export WEEZTERM_D2B_BOUND_TARGET="$TARGET"
+export WEEZTERM_D2B_BOUND_VM="$TARGET"
+unset WEZTERM_UNIX_SOCKET WEEZTERM_UNIX_SOCKET
+
+"$WEZTERM_GUI_BIN" --config-file "$WEZTERM_CONFIG" start \
+  --always-new-process --no-auto-connect \
+  >"$ARTIFACT_DIR/wezterm.log" 2>&1 &
+WEZTERM_PID=$!
+
+MUX_SOCKET=$(wait_for_discovered_socket "gui-sock-d2b-*" "" "$WEZTERM_PID" "WezTerm d2b mux")
+assert_private_socket "$MUX_SOCKET" "WezTerm mux socket"
+export WEEZTERM_UNIX_SOCKET="$MUX_SOCKET"
+unset WEZTERM_UNIX_SOCKET
+
+wezterm_cli() {
+  WEEZTERM_UNIX_SOCKET="$MUX_SOCKET" \
+    "$WEZTERM_BIN" --config-file "$WEZTERM_CONFIG" cli --no-auto-start "$@"
+}
+
+PANES_JSON="$ARTIFACT_DIR/panes.json"
+deadline=$((SECONDS + READY_TIMEOUT))
+while :; do
+  process_alive "$WEZTERM_PID" || die "WezTerm exited before two d2b tabs were ready"
+  if wezterm_cli list --format json >"$PANES_JSON.next" 2>>"$ARTIFACT_DIR/wezterm-cli.log" &&
+    jq -e '
+      length == 2
+      and (map(.window_id) | unique | length == 1)
+      and (map(.tab_id) | unique | length == 2)
+    ' "$PANES_JSON.next" >/dev/null; then
+    mv -- "$PANES_JSON.next" "$PANES_JSON"
+    break
+  fi
+  ((SECONDS < deadline)) || die "timed out waiting for two tabs on the private WezTerm mux"
+  sleep 0.1
+done
+
+mapfile -t IDS < <(
+  jq -r 'sort_by(.tab_id)[] | [.tab_id, .pane_id] | @tsv' "$PANES_JSON"
+)
+((${#IDS[@]} == 2)) || die "unable to identify exactly two tabs from panes.json"
+IFS=$'\t' read -r TAB_ONE PANE_ONE <<<"${IDS[0]}"
+IFS=$'\t' read -r TAB_TWO PANE_TWO <<<"${IDS[1]}"
+D2B_IDENTITY=$(
+  jq -r --argjson pane "$PANE_ONE" '
+    .[]
+    | select(.pane_id == $pane)
+    | .title
+    | capture("\\[(?<identity>[^][]+:[^][]+)\\]$").identity
+  ' "$PANES_JSON"
+)
+[[ -n "$D2B_IDENTITY" ]] ||
+  die "first pane did not expose a trusted [target:shell] title in panes.json"
+
+send_osc_title() {
+  local pane=$1
+  local title=$2
+  local payload
+  payload="printf '\\033]0;${title}\\007'"$'\r'
+  wezterm_cli send-text --pane-id "$pane" --no-paste "$payload" \
+    >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+}
+
+wait_for_pane_title() {
+  local pane=$1
+  local title=$2
+  local deadline=$((SECONDS + TITLE_TIMEOUT))
+  local json="$RUNTIME_DIR/panes-current.json"
+  while :; do
+    process_alive "$WEZTERM_PID" || die "WezTerm exited while waiting for pane $pane title '$title'"
+    if wezterm_cli list --format json >"$json" 2>>"$ARTIFACT_DIR/wezterm-cli.log" &&
+      jq -e --argjson pane "$pane" --arg title "$title" '
+        any(.[]; .pane_id == $pane and (.title | contains($title)))
+      ' "$json" >/dev/null; then
+      return 0
+    fi
+    ((SECONDS < deadline)) || die "timed out waiting for pane $pane to report OSC title '$title'"
+    sleep 0.1
+  done
+}
+
+normalize_text() {
+  tr '[:upper:]' '[:lower:]' |
+    sed -E 's/[^a-z0-9]+/ /g; s/^ +//; s/ +$//; s/ +/ /g'
+}
+
+capture_until_title() {
+  local name=$1
+  local expected=$2
+  local expected_normalized
+  expected_normalized=$(printf '%s' "$expected" | normalize_text)
+  local deadline=$((SECONDS + TITLE_TIMEOUT))
+  local raw="$RUNTIME_DIR/$name-raw.png"
+  local full="$ARTIFACT_DIR/$name.png"
+  local crop="$ARTIFACT_DIR/$name-title.png"
+  local ocr="$ARTIFACT_DIR/$name-ocr.txt"
+  local width bytes actual_normalized
+
+  printf '%s\n' "$expected" >"$ARTIFACT_DIR/$name-expected.txt"
+  while :; do
+    process_alive "$WEZTERM_PID" || die "WezTerm exited while capturing '$expected'"
+    WAYLAND_DISPLAY="$WAYLAND_DISPLAY" grim "$raw"
+    magick "$raw" -strip -define png:compression-level=9 "$full"
+    width=$(identify -format '%w' "$full")
+    magick "$full" -gravity North -crop "${width}x32+0+0" +repage \
+      -colorspace Gray -contrast-stretch 1%x1% -filter Lanczos -resize 400% \
+      -strip -define png:compression-level=9 "$crop"
+    tesseract "$crop" stdout --psm 7 2>>"$ARTIFACT_DIR/tesseract.log" >"$ocr" || true
+    actual_normalized=$(normalize_text <"$ocr")
+    printf '%s\n' "$actual_normalized" >"$ARTIFACT_DIR/$name-ocr-normalized.txt"
+
+    if [[ " $actual_normalized " == *" $expected_normalized "* ]]; then
+      for png in "$full" "$crop"; do
+        bytes=$(stat -c '%s' "$png")
+        ((bytes < 5 * 1024 * 1024)) ||
+          die "$png is $bytes bytes; expected less than 5 MB"
+      done
+      return 0
+    fi
+    ((SECONDS < deadline)) ||
+      die "OCR did not find '$expected' in $name-title.png; normalized OCR was '$actual_normalized'"
+    sleep 0.15
+  done
+}
+
+TITLE_ONE="first-latest"
+TITLE_TWO_INITIAL="second-initial"
+TITLE_TWO_UPDATED="second-updated"
+TITLE_LONG="fake-admin-padding-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+EXPECTED_TITLE_ONE="$TITLE_ONE [$D2B_IDENTITY]"
+EXPECTED_TITLE_TWO="$TITLE_TWO_UPDATED [$TARGET:$SHELL_TWO]"
+if ((SECOND_LOCAL == 1)); then
+  EXPECTED_TITLE_TWO="[2/2] $TITLE_TWO_UPDATED"
+fi
+
+send_osc_title "$PANE_ONE" "$TITLE_ONE"
+wait_for_pane_title "$PANE_ONE" "$TITLE_ONE"
+send_osc_title "$PANE_TWO" "$TITLE_TWO_INITIAL"
+wait_for_pane_title "$PANE_TWO" "$TITLE_TWO_INITIAL"
+wezterm_cli activate-tab --tab-id "$TAB_ONE" >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+capture_until_title "01-first-active" "$EXPECTED_TITLE_ONE"
+
+send_osc_title "$PANE_TWO" "$TITLE_TWO_UPDATED"
+wait_for_pane_title "$PANE_TWO" "$TITLE_TWO_UPDATED"
+wezterm_cli activate-tab --tab-id "$TAB_TWO" >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+capture_until_title "02-background-updated-active" "$EXPECTED_TITLE_TWO"
+
+wezterm_cli activate-tab --tab-id "$TAB_ONE" >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+capture_until_title "03-switched-back" "$EXPECTED_TITLE_ONE"
+
+wezterm_cli activate-tab --tab-id "$TAB_TWO" >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+capture_until_title "04-switched-again" "$EXPECTED_TITLE_TWO"
+
+send_osc_title "$PANE_ONE" "$TITLE_LONG"
+wait_for_pane_title "$PANE_ONE" "fake-admin-padding"
+wezterm_cli activate-tab --tab-id "$TAB_ONE" >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+capture_until_title "05-long-title-keeps-identity" "[$D2B_IDENTITY]"
+
+{
+  printf 'target=%s\n' "$TARGET"
+  printf 'domain=%s\n' "$DOMAIN"
+  printf 'shell_one=%s\n' "$SHELL_ONE"
+  printf 'shell_two=%s\n' "$SHELL_TWO"
+  printf 'd2b_identity=%s\n' "$D2B_IDENTITY"
+  printf 'second_local=%s\n' "$SECOND_LOCAL"
+  printf 'mux_socket=%s\n' "$MUX_SOCKET"
+} >"$ARTIFACT_DIR/run.txt"
+
+printf 'wayland-title: passed; artifacts: %s\n' "$ARTIFACT_DIR"

--- a/wezterm-gui/src/overlay/d2b_launcher.rs
+++ b/wezterm-gui/src/overlay/d2b_launcher.rs
@@ -3,7 +3,7 @@ use crate::termwindow::TermWindowNotif;
 use config::keyassignment::KeyAssignment;
 use mux::d2b::{
     friendly_session_name, sanitize_display_label, validate_shell_name, D2bDomain, D2bSession,
-    D2bTargetStatus,
+    D2bTargetStatus, ShellSessionState,
 };
 use mux::domain::Domain;
 use mux::termwiztermtab::TermWizTerminal;
@@ -18,6 +18,18 @@ use window::WindowOps;
 
 const ROW_OVERHEAD: usize = 3;
 const ALPHABET: &str = "1234567890abcdefghilmnopqrstuvwxyz";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct D2bTargetScope {
+    pub domain_name: String,
+    pub target: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PickerKind {
+    AllTargets,
+    CurrentTarget,
+}
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct D2bTargetPickerEntry {
@@ -70,10 +82,19 @@ struct Entry {
 pub struct D2bLauncherArgs {
     pane_id: mux::pane::PaneId,
     targets: Vec<D2bTargetPickerEntry>,
+    kind: PickerKind,
 }
 
 impl D2bLauncherArgs {
     pub async fn new(pane_id: mux::pane::PaneId) -> Self {
+        Self::collect(pane_id, None).await
+    }
+
+    pub async fn new_scoped(pane_id: mux::pane::PaneId, scope: D2bTargetScope) -> Self {
+        Self::collect(pane_id, Some(scope)).await
+    }
+
+    async fn collect(pane_id: mux::pane::PaneId, scope: Option<D2bTargetScope>) -> Self {
         let mux = Mux::get();
         let mut targets = vec![];
         for domain in mux.iter_domains() {
@@ -81,6 +102,12 @@ impl D2bLauncherArgs {
                 continue;
             };
             let domain_name = d2b.domain_name().to_string();
+            if scope
+                .as_ref()
+                .is_some_and(|scope| scope.domain_name != domain_name)
+            {
+                continue;
+            }
             let configured_target = d2b.target().to_string();
             match d2b.discover().await {
                 Ok(discovery) => {
@@ -90,6 +117,23 @@ impl D2bLauncherArgs {
                         .map(|session| session.id.clone())
                         .collect::<Vec<_>>();
                     let target = discovery.status.target().to_string();
+                    if scope.as_ref().is_some_and(|scope| scope.target != target) {
+                        let trusted_target = scope
+                            .as_ref()
+                            .map(|scope| scope.target.clone())
+                            .unwrap_or(configured_target);
+                        targets.push(D2bTargetPickerEntry {
+                            domain_name,
+                            generated_name: friendly_session_name(&trusted_target, &names),
+                            target: trusted_target,
+                            status: None,
+                            unavailable_reason: Some(
+                                "trusted target identity mismatch".to_string(),
+                            ),
+                            sessions: vec![],
+                        });
+                        continue;
+                    }
                     let generated_name = friendly_session_name(&target, &names);
                     targets.push(D2bTargetPickerEntry {
                         domain_name,
@@ -102,15 +146,31 @@ impl D2bLauncherArgs {
                 }
                 Err(err) => {
                     log::debug!("d2b discovery failed: {err:#}");
+                    let target = scope
+                        .as_ref()
+                        .map(|scope| scope.target.clone())
+                        .unwrap_or(configured_target);
                     targets.push(D2bTargetPickerEntry {
                         domain_name,
-                        target: configured_target.clone(),
+                        generated_name: friendly_session_name(&target, &[]),
+                        target,
                         status: None,
                         unavailable_reason: Some(sanitize_display_label(&err.to_string())),
                         sessions: vec![],
-                        generated_name: friendly_session_name(&configured_target, &[]),
                     });
                 }
+            }
+        }
+        if let Some(scope) = &scope {
+            if targets.is_empty() {
+                targets.push(D2bTargetPickerEntry {
+                    domain_name: scope.domain_name.clone(),
+                    target: scope.target.clone(),
+                    status: None,
+                    unavailable_reason: Some("trusted d2b domain is unavailable".to_string()),
+                    sessions: vec![],
+                    generated_name: friendly_session_name(&scope.target, &[]),
+                });
             }
         }
         targets.sort_by(|a, b| {
@@ -118,7 +178,15 @@ impl D2bLauncherArgs {
                 .cmp(&b.target)
                 .then(a.domain_name.cmp(&b.domain_name))
         });
-        Self { pane_id, targets }
+        Self {
+            pane_id,
+            targets,
+            kind: if scope.is_some() {
+                PickerKind::CurrentTarget
+            } else {
+                PickerKind::AllTargets
+            },
+        }
     }
 }
 
@@ -147,7 +215,7 @@ struct State {
 impl State {
     fn new(args: D2bLauncherArgs, window: ::window::Window) -> Self {
         Self {
-            entries: build_entries(&args.targets),
+            entries: build_entries(&args.targets, args.kind),
             args,
             window,
             active_idx: 0,
@@ -184,7 +252,12 @@ impl State {
                 x: Position::Absolute(0),
                 y: Position::Absolute(0),
             },
-            Change::Text("d2b sessions: Enter=open  n=name new  Esc=cancel\r\n".to_string()),
+            Change::Text(match self.args.kind {
+                PickerKind::AllTargets => {
+                    "d2b sessions: Enter=open  n=name new  Esc=cancel\r\n".to_string()
+                }
+                PickerKind::CurrentTarget => "d2b shells: Enter=open  Esc=cancel\r\n".to_string(),
+            }),
             Change::AllAttributes(CellAttributes::default()),
         ];
         let max_label_len = self.labels.iter().map(|s| s.len()).max().unwrap_or(0);
@@ -460,7 +533,7 @@ impl State {
     }
 }
 
-fn build_entries(targets: &[D2bTargetPickerEntry]) -> Vec<Entry> {
+fn build_entries(targets: &[D2bTargetPickerEntry], kind: PickerKind) -> Vec<Entry> {
     let mut entries = vec![];
     for target in targets {
         let target_label = sanitize_display_label(&target.target);
@@ -478,6 +551,42 @@ fn build_entries(targets: &[D2bTargetPickerEntry]) -> Vec<Entry> {
             .as_deref()
             .map(|warning| format!(" — {warning}"))
             .unwrap_or_default();
+
+        if kind == PickerKind::CurrentTarget {
+            entries.push(Entry {
+                label: format!(
+                    "New d2b shell `[{target_label}:{}]`{posture}",
+                    sanitize_display_label(&target.generated_name)
+                ),
+                disabled: false,
+                action: EntryAction::Open {
+                    domain: target.domain_name.clone(),
+                    name: target.generated_name.clone(),
+                },
+            });
+
+            let mut sessions = target
+                .sessions
+                .iter()
+                .filter(|session| !session.attached && session.state == ShellSessionState::Detached)
+                .cloned()
+                .collect::<Vec<_>>();
+            sessions.sort_by(|a, b| b.is_default.cmp(&a.is_default).then(a.id.cmp(&b.id)));
+            for session in sessions {
+                let session_label = sanitize_display_label(&session.id);
+                entries.push(Entry {
+                    label: format!(
+                        "Reattach d2b shell `[{target_label}:{session_label}]`{posture}"
+                    ),
+                    disabled: false,
+                    action: EntryAction::Open {
+                        domain: target.domain_name.clone(),
+                        name: session.id,
+                    },
+                });
+            }
+            continue;
+        }
 
         entries.push(Entry {
             label: format!(
@@ -571,14 +680,17 @@ mod test {
 
     #[test]
     fn entries_disable_offline_targets_without_open_actions() {
-        let entries = build_entries(&[D2bTargetPickerEntry {
-            domain_name: "d2b-work".to_string(),
-            target: "work".to_string(),
-            status: None,
-            unavailable_reason: Some("offline".to_string()),
-            sessions: vec![],
-            generated_name: "work-shell".to_string(),
-        }]);
+        let entries = build_entries(
+            &[D2bTargetPickerEntry {
+                domain_name: "d2b-work".to_string(),
+                target: "work".to_string(),
+                status: None,
+                unavailable_reason: Some("offline".to_string()),
+                sessions: vec![],
+                generated_name: "work-shell".to_string(),
+            }],
+            PickerKind::AllTargets,
+        );
         assert_eq!(entries.len(), 1);
         assert!(entries[0].disabled);
         assert_eq!(entries[0].action, EntryAction::Disabled);
@@ -586,14 +698,17 @@ mod test {
 
     #[test]
     fn entries_include_generated_manual_and_existing_sessions() {
-        let entries = build_entries(&[D2bTargetPickerEntry {
-            domain_name: "d2b-work".to_string(),
-            target: "work".to_string(),
-            status: Some(ready_status("work")),
-            unavailable_reason: None,
-            sessions: vec![session("default", true), session("build", false)],
-            generated_name: "work-shell".to_string(),
-        }]);
+        let entries = build_entries(
+            &[D2bTargetPickerEntry {
+                domain_name: "d2b-work".to_string(),
+                target: "work".to_string(),
+                status: Some(ready_status("work")),
+                unavailable_reason: None,
+                sessions: vec![session("default", true), session("build", false)],
+                generated_name: "work-shell".to_string(),
+            }],
+            PickerKind::AllTargets,
+        );
         assert!(entries
             .iter()
             .any(|entry| entry.label.contains("work-shell")));
@@ -608,14 +723,17 @@ mod test {
 
     #[test]
     fn entries_sanitize_target_and_session_labels() {
-        let entries = build_entries(&[D2bTargetPickerEntry {
-            domain_name: "d2b-work".to_string(),
-            target: "work\x1b[31m".to_string(),
-            status: Some(ready_status("work")),
-            unavailable_reason: None,
-            sessions: vec![session("bad\x07\x1b[31m", false)],
-            generated_name: "work-shell".to_string(),
-        }]);
+        let entries = build_entries(
+            &[D2bTargetPickerEntry {
+                domain_name: "d2b-work".to_string(),
+                target: "work\x1b[31m".to_string(),
+                status: Some(ready_status("work")),
+                unavailable_reason: None,
+                sessions: vec![session("bad\x07\x1b[31m", false)],
+                generated_name: "work-shell".to_string(),
+            }],
+            PickerKind::AllTargets,
+        );
         let combined = entries
             .iter()
             .map(|entry| entry.label.as_str())
@@ -636,14 +754,17 @@ mod test {
             true,
         )
         .unwrap();
-        let entries = build_entries(&[D2bTargetPickerEntry {
-            domain_name: "host-tools".to_string(),
-            target: "tools.host.d2b".to_string(),
-            status: Some(status),
-            unavailable_reason: None,
-            sessions: vec![],
-            generated_name: "d2b-tools-shell".to_string(),
-        }]);
+        let entries = build_entries(
+            &[D2bTargetPickerEntry {
+                domain_name: "host-tools".to_string(),
+                target: "tools.host.d2b".to_string(),
+                status: Some(status),
+                unavailable_reason: None,
+                sessions: vec![],
+                generated_name: "d2b-tools-shell".to_string(),
+            }],
+            PickerKind::AllTargets,
+        );
 
         assert!(entries.iter().all(|entry| !entry.disabled));
         assert!(entries
@@ -661,18 +782,65 @@ mod test {
             true,
         )
         .unwrap();
-        let entries = build_entries(&[D2bTargetPickerEntry {
-            domain_name: "host-tools".to_string(),
-            target: "tools.host.d2b".to_string(),
-            status: Some(status),
-            unavailable_reason: None,
-            sessions: vec![],
-            generated_name: "d2b-tools-shell".to_string(),
-        }]);
+        let entries = build_entries(
+            &[D2bTargetPickerEntry {
+                domain_name: "host-tools".to_string(),
+                target: "tools.host.d2b".to_string(),
+                status: Some(status),
+                unavailable_reason: None,
+                sessions: vec![],
+                generated_name: "d2b-tools-shell".to_string(),
+            }],
+            PickerKind::AllTargets,
+        );
 
         assert_eq!(entries.len(), 1);
         assert!(entries[0].disabled);
         assert!(entries[0].label.contains("UNSAFE LOCAL — NO ISOLATION"));
         assert!(entries[0].label.contains("helper unavailable"));
+    }
+
+    #[test]
+    fn scoped_entries_create_immediately_and_only_reattach_detached_shells() {
+        let mut attached = session("attached", false);
+        attached.state = ShellSessionState::Attached;
+        attached.attached = true;
+        let mut killed = session("killed", false);
+        killed.state = ShellSessionState::Killed;
+        let entries = build_entries(
+            &[D2bTargetPickerEntry {
+                domain_name: "host-tools".to_string(),
+                target: "tools.host.d2b".to_string(),
+                status: Some(ready_status("tools.host.d2b")),
+                unavailable_reason: None,
+                sessions: vec![
+                    session("detached", false),
+                    attached,
+                    killed,
+                    session("default", true),
+                ],
+                generated_name: "new-shell".to_string(),
+            }],
+            PickerKind::CurrentTarget,
+        );
+
+        assert_eq!(entries.len(), 3);
+        assert!(entries[0].label.contains("[tools.host.d2b:new-shell]"));
+        assert!(matches!(
+            &entries[0].action,
+            EntryAction::Open { name, .. } if name == "new-shell"
+        ));
+        assert!(entries
+            .iter()
+            .all(|entry| !matches!(entry.action, EntryAction::Manual { .. })));
+        let labels = entries
+            .iter()
+            .map(|entry| entry.label.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(labels.contains("detached"));
+        assert!(labels.contains("default"));
+        assert!(!labels.contains("attached"));
+        assert!(!labels.contains("killed"));
     }
 }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -155,7 +155,6 @@ fn compute_tab_title(
                 } else {
                     tab.tab_title.clone()
                 };
-
                 let classic_spacing = if config.use_fancy_tab_bar { "" } else { " " };
                 if config.show_tab_index_in_tab_bar {
                     let index = format!(
@@ -191,6 +190,14 @@ fn compute_tab_title(
                         // TODO: Decide what to do here to indicate this
                     }
                 }
+
+                // --- weezterm remote features ---
+                title = crate::termwindow::effective_tab_title_for_width(
+                    tab,
+                    title,
+                    tab_max_width.saturating_sub(len),
+                );
+                // --- end weezterm remote features ---
 
                 // We have a preferred soft minimum on tab width to make it
                 // easier to click on tab titles, but we'll still go below

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -283,7 +283,11 @@ pub struct PaneInformation {
     pub pixel_height: usize,
     pub title: String,
     pub user_vars: HashMap<String, String>,
+    // --- weezterm remote features ---
     pub trusted_d2b_target: Option<String>,
+    pub trusted_d2b_session: Option<String>,
+    pub d2b_guest_title: Option<String>,
+    // --- end weezterm remote features ---
     pub progress: Progress,
 }
 
@@ -353,30 +357,71 @@ impl UserData for PaneInformation {
 }
 
 // --- weezterm remote features ---
-fn d2b_window_title(
-    active_pane: &PaneInformation,
-    tabs: &[TabInformation],
-    num_tabs: usize,
-) -> Option<String> {
-    fn pane_target(pane: &PaneInformation) -> Option<&String> {
-        pane.trusted_d2b_target.as_ref()
-    }
-
-    let target = pane_target(active_pane)?;
-    let same_target = tabs
-        .iter()
-        .filter(|tab| tab.active_pane.as_ref().and_then(pane_target) == Some(target))
-        .count();
-
-    if same_target > 1 {
-        Some(format!(
-            "d2b {target} ({same_target} sessions) - {}",
-            active_pane.title
-        ))
-    } else if num_tabs == 1 {
-        Some(active_pane.title.clone())
+fn effective_tab_title_impl(
+    tab: &TabInformation,
+    default_title: String,
+    max_width: Option<usize>,
+) -> String {
+    let Some(pane) = tab.active_pane.as_ref() else {
+        return default_title;
+    };
+    if let (Some(target), Some(session)) = (
+        pane.trusted_d2b_target.as_deref(),
+        pane.trusted_d2b_session.as_deref(),
+    ) {
+        let guest_title = if tab.tab_title.is_empty() {
+            pane.d2b_guest_title.as_deref().unwrap_or(&default_title)
+        } else {
+            &default_title
+        };
+        if let Some(max_width) = max_width {
+            mux::d2b::d2b_tab_title_for_width(target, session, guest_title, max_width)
+        } else {
+            mux::d2b::d2b_tab_title(target, session, guest_title)
+        }
     } else {
-        None
+        default_title
+    }
+}
+
+pub(crate) fn effective_tab_title(tab: &TabInformation, default_title: String) -> String {
+    effective_tab_title_impl(tab, default_title, None)
+}
+
+pub(crate) fn effective_tab_title_for_width(
+    tab: &TabInformation,
+    default_title: String,
+    max_width: usize,
+) -> String {
+    effective_tab_title_impl(tab, default_title, Some(max_width))
+}
+
+fn d2b_window_title(active_tab: &TabInformation) -> Option<String> {
+    let pane = active_tab.active_pane.as_ref()?;
+    pane.trusted_d2b_target.as_ref()?;
+    pane.trusted_d2b_session.as_ref()?;
+    let default_title = if active_tab.tab_title.is_empty() {
+        pane.title.clone()
+    } else {
+        active_tab.tab_title.clone()
+    };
+    Some(effective_tab_title(active_tab, default_title))
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NewTabDropdownTarget {
+    D2b(crate::overlay::d2b_launcher::D2bTargetScope),
+    Generic,
+}
+
+#[cfg(target_os = "linux")]
+fn new_tab_dropdown_target(
+    scope: Option<crate::overlay::d2b_launcher::D2bTargetScope>,
+) -> NewTabDropdownTarget {
+    match scope {
+        Some(scope) => NewTabDropdownTarget::D2b(scope),
+        None => NewTabDropdownTarget::Generic,
     }
 }
 // --- end weezterm remote features ---
@@ -385,7 +430,7 @@ fn d2b_window_title(
 mod d2b_title_tests {
     use super::*;
 
-    fn pane_with_untrusted_target() -> PaneInformation {
+    fn pane_with_untrusted_target(title: &str) -> PaneInformation {
         PaneInformation {
             pane_id: 999_999,
             pane_index: 0,
@@ -398,23 +443,101 @@ mod d2b_title_tests {
             height: 24,
             pixel_width: 800,
             pixel_height: 600,
-            title: "shell".to_owned(),
+            title: title.to_owned(),
             user_vars: HashMap::from([(
                 "weezterm.d2b.target".to_owned(),
                 "spoofed.host.d2b".to_owned(),
             )]),
             trusted_d2b_target: None,
+            trusted_d2b_session: None,
+            d2b_guest_title: None,
             progress: Progress::default(),
+        }
+    }
+
+    fn tab_with_pane(pane: PaneInformation, tab_title: &str) -> TabInformation {
+        TabInformation {
+            tab_id: 999_999,
+            tab_index: 0,
+            is_active: true,
+            is_last_active: false,
+            active_pane: Some(pane),
+            window_id: 999_999,
+            tab_title: tab_title.to_owned(),
         }
     }
 
     #[test]
     fn terminal_user_vars_cannot_claim_d2b_window_identity() {
-        let mut pane = pane_with_untrusted_target();
-        assert_eq!(d2b_window_title(&pane, &[], 1), None);
+        let mut pane = pane_with_untrusted_target("shell");
+        assert_eq!(d2b_window_title(&tab_with_pane(pane.clone(), "")), None);
 
         pane.trusted_d2b_target = Some("tools.host.d2b".to_owned());
-        assert_eq!(d2b_window_title(&pane, &[], 1), Some("shell".to_owned()));
+        assert_eq!(d2b_window_title(&tab_with_pane(pane.clone(), "")), None);
+
+        pane.trusted_d2b_session = Some("handy-kingbird".to_owned());
+        assert_eq!(
+            d2b_window_title(&tab_with_pane(pane, "")),
+            Some("shell [tools.host.d2b:handy-kingbird]".to_owned())
+        );
+    }
+
+    #[test]
+    fn explicit_tab_title_gets_the_trusted_d2b_suffix() {
+        let mut pane = pane_with_untrusted_target("copilot [tools.host.d2b:handy-kingbird]");
+        pane.trusted_d2b_target = Some("tools.host.d2b".to_owned());
+        pane.trusted_d2b_session = Some("handy-kingbird".to_owned());
+        pane.d2b_guest_title = Some("copilot".to_owned());
+
+        assert_eq!(
+            d2b_window_title(&tab_with_pane(pane, "reviewing")),
+            Some("reviewing [tools.host.d2b:handy-kingbird]".to_owned())
+        );
+    }
+
+    #[test]
+    fn switching_tabs_uses_each_tabs_latest_title() {
+        let mut first = pane_with_untrusted_target("first-new [tools.host.d2b:first]");
+        first.trusted_d2b_target = Some("tools.host.d2b".to_owned());
+        first.trusted_d2b_session = Some("first".to_owned());
+        first.d2b_guest_title = Some("first-new".to_owned());
+        let mut second = pane_with_untrusted_target("second-old [tools.host.d2b:second]");
+        second.trusted_d2b_target = Some("tools.host.d2b".to_owned());
+        second.trusted_d2b_session = Some("second".to_owned());
+        second.d2b_guest_title = Some("second-old".to_owned());
+
+        let first_tab = tab_with_pane(first, "");
+        second.title = "second-new [tools.host.d2b:second]".to_owned();
+        second.d2b_guest_title = Some("second-new".to_owned());
+        let second_tab = tab_with_pane(second, "");
+
+        assert_eq!(
+            d2b_window_title(&first_tab),
+            Some("first-new [tools.host.d2b:first]".to_owned())
+        );
+        assert_eq!(
+            d2b_window_title(&second_tab),
+            Some("second-new [tools.host.d2b:second]".to_owned())
+        );
+        assert_eq!(
+            d2b_window_title(&first_tab),
+            Some("first-new [tools.host.d2b:first]".to_owned())
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn new_tab_dropdown_routes_only_trusted_d2b_scopes_to_the_d2b_picker() {
+        assert_eq!(new_tab_dropdown_target(None), NewTabDropdownTarget::Generic);
+
+        let scope = crate::overlay::d2b_launcher::D2bTargetScope {
+            domain_name: "host-tools".to_owned(),
+            target: "tools.host.d2b".to_owned(),
+        };
+        assert_eq!(
+            new_tab_dropdown_target(Some(scope.clone())),
+            NewTabDropdownTarget::D2b(scope)
+        );
     }
 }
 
@@ -2841,7 +2964,7 @@ impl TermWindow {
             None => {
                 if let (Some(pos), Some(tab)) = (active_pane, active_tab) {
                     // --- weezterm remote features ---
-                    if let Some(title) = d2b_window_title(&pos, &tabs, num_tabs) {
+                    if let Some(title) = d2b_window_title(&tab) {
                         title
                     } else if num_tabs == 1 {
                         format!("{}{}", if pos.is_zoomed { "[Z] " } else { "" }, pos.title)
@@ -3467,6 +3590,17 @@ impl TermWindow {
 
     // --- weezterm remote features ---
     fn show_new_tab_dropdown(&mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            match new_tab_dropdown_target(self.active_d2b_target_scope()) {
+                NewTabDropdownTarget::D2b(scope) => {
+                    self.show_d2b_launcher_impl(Some(scope));
+                    return;
+                }
+                NewTabDropdownTarget::Generic => {}
+            }
+        }
+
         let title = "New Tab".to_string();
         let args = LauncherActionArgs {
             title: Some(title),
@@ -3476,6 +3610,21 @@ impl TermWindow {
             alphabet: None,
         };
         self.show_launcher_impl(args, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn active_d2b_target_scope(&self) -> Option<crate::overlay::d2b_launcher::D2bTargetScope> {
+        let mux = Mux::get();
+        let tab = mux.get_active_tab_for_window(self.mux_window_id)?;
+        let pane = tab.get_active_pane()?;
+        let target = pane.trusted_d2b_target()?.to_string();
+        pane.trusted_d2b_session()?;
+        let domain = mux.get_domain(pane.domain_id())?;
+        let d2b = domain.downcast_ref::<mux::d2b::D2bDomain>()?;
+        Some(crate::overlay::d2b_launcher::D2bTargetScope {
+            domain_name: mux::domain::Domain::domain_name(d2b).to_string(),
+            target,
+        })
     }
     // --- end weezterm remote features ---
 
@@ -3581,13 +3730,21 @@ impl TermWindow {
     // --- weezterm remote features ---
     #[cfg(target_os = "linux")]
     fn show_d2b_launcher(&mut self) {
+        self.show_d2b_launcher_impl(None);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn show_d2b_launcher_impl(
+        &mut self,
+        scope: Option<crate::overlay::d2b_launcher::D2bTargetScope>,
+    ) {
         let window = self.window.as_ref().unwrap().clone();
         let mux = Mux::get();
         let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
             Some(tab) => tab,
             None => return,
         };
-        let pane = match self.get_active_pane_or_overlay() {
+        let pane = match tab.get_active_pane() {
             Some(pane) => pane,
             None => return,
         };
@@ -3595,7 +3752,12 @@ impl TermWindow {
         let tab_id = tab.tab_id();
 
         promise::spawn::spawn(async move {
-            let args = crate::overlay::d2b_launcher::D2bLauncherArgs::new(pane_id).await;
+            let args = match scope {
+                Some(scope) => {
+                    crate::overlay::d2b_launcher::D2bLauncherArgs::new_scoped(pane_id, scope).await
+                }
+                None => crate::overlay::d2b_launcher::D2bLauncherArgs::new(pane_id).await,
+            };
             let win = window.clone();
             win.notify(TermWindowNotif::Apply(Box::new(move |term_window| {
                 let mux = Mux::get();
@@ -4633,7 +4795,11 @@ impl TermWindow {
             pixel_height: pos.pixel_height,
             title: pos.pane.get_title(),
             user_vars: pos.pane.copy_user_vars(),
+            // --- weezterm remote features ---
             trusted_d2b_target: pos.pane.trusted_d2b_target().map(str::to_owned),
+            trusted_d2b_session: pos.pane.trusted_d2b_session().map(str::to_owned),
+            d2b_guest_title: pos.pane.d2b_guest_title(),
+            // --- end weezterm remote features ---
             progress: pos.pane.get_progress(),
         }
     }

--- a/window/src/os/wayland/titlebar_frame.rs
+++ b/window/src/os/wayland/titlebar_frame.rs
@@ -1,10 +1,12 @@
 // --- weezterm remote features ---
 use std::error::Error;
 use std::marker::PhantomData;
-use std::mem;
 use std::num::NonZeroU32;
+use std::ops::Deref;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{fmt, mem};
 
 use smithay_client_toolkit::compositor::SurfaceData;
 use smithay_client_toolkit::reexports::client::protocol::wl_shm;
@@ -19,7 +21,9 @@ use smithay_client_toolkit::shell::WaylandSurface;
 use smithay_client_toolkit::shm::slot::SlotPool;
 use smithay_client_toolkit::shm::Shm;
 use smithay_client_toolkit::subcompositor::{SubcompositorState, SubsurfaceData};
+use tiny_skia::{ColorU8, PixmapMut, PixmapPaint, PixmapRef, Transform};
 use wayland_backend::client::ObjectId;
+use wezterm_font::{FontConfiguration, FontMetrics, GlyphInfo, RasterizedGlyph};
 
 const HEADER_SIZE: u32 = 24;
 
@@ -43,7 +47,70 @@ pub struct TitleBarFrame<State> {
     pool: SlotPool,
     subcompositor: Arc<SubcompositorState>,
     buttons: [Option<UIButton>; 3],
+    font_config: TitleFontConfig,
+    title: String,
+    shaped_title: Option<ShapedTitle>,
     _state: PhantomData<State>,
+}
+
+#[repr(transparent)]
+struct TitleFontConfig(Rc<FontConfiguration>);
+
+impl fmt::Debug for TitleFontConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TitleFontConfig")
+    }
+}
+
+impl Deref for TitleFontConfig {
+    type Target = FontConfiguration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct ShapedTitle {
+    title: String,
+    glyphs: Vec<ShapedGlyph>,
+    metrics: FontMetrics,
+    is_active: bool,
+    dpi: usize,
+}
+
+impl fmt::Debug for ShapedTitle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ShapedTitle")
+            .field("title", &self.title)
+            .field("glyph_count", &self.glyphs.len())
+            .field("metrics", &self.metrics)
+            .field("is_active", &self.is_active)
+            .field("dpi", &self.dpi)
+            .finish()
+    }
+}
+
+struct ShapedGlyph {
+    info: GlyphInfo,
+    glyph: RasterizedGlyph,
+}
+
+fn title_tail_start(advances: &[f64], available_width: f64) -> usize {
+    if advances.iter().sum::<f64>() <= available_width {
+        return 0;
+    }
+
+    let mut tail_width = 0.;
+    let mut start = advances.len();
+    for (idx, advance) in advances.iter().enumerate().rev() {
+        if tail_width + advance > available_width {
+            break;
+        }
+        tail_width += advance;
+        start = idx;
+    }
+    start
 }
 
 impl<State> TitleBarFrame<State>
@@ -55,6 +122,7 @@ where
         shm: &Shm,
         subcompositor: Arc<SubcompositorState>,
         queue_handle: QueueHandle<State>,
+        font_config: Rc<FontConfiguration>,
     ) -> Result<Self, Box<dyn Error>> {
         let parent = parent.wl_surface().clone();
         let pool = SlotPool::new(1, shm)?;
@@ -75,8 +143,131 @@ where
             pool,
             subcompositor,
             buttons: Self::supported_buttons(wm_capabilities),
+            font_config: TitleFontConfig(font_config),
+            title: String::new(),
+            shaped_title: None,
             _state: PhantomData,
         })
+    }
+
+    fn reshape_title(&mut self, is_active: bool) -> Option<()> {
+        if self.title.is_empty() {
+            self.shaped_title.take();
+            return Some(());
+        }
+
+        if let Some(existing) = self.shaped_title.as_ref() {
+            if existing.title == self.title
+                && existing.is_active == is_active
+                && existing.dpi == self.font_config.get_dpi()
+            {
+                return Some(());
+            }
+        }
+
+        let font = self.font_config.title_font().ok()?;
+        let metrics = font.metrics();
+        let infos = font
+            .shape(
+                &self.title,
+                || {},
+                |_| {},
+                None,
+                wezterm_bidi::Direction::LeftToRight,
+                None,
+                None,
+            )
+            .ok()?;
+        let color_level = if is_active { 0xcc } else { 0x99 };
+        let mut glyphs = vec![];
+
+        for info in infos {
+            if let Ok(mut glyph) = font.rasterize_glyph(info.glyph_pos, info.font_idx) {
+                if let Some(mut data) =
+                    PixmapMut::from_bytes(&mut glyph.data, glyph.width as u32, glyph.height as u32)
+                {
+                    for pixel in data.pixels_mut() {
+                        let color = pixel.demultiply();
+                        let (red, green, blue, alpha) =
+                            (color.red(), color.green(), color.blue(), color.alpha());
+                        if glyph.has_color {
+                            *pixel = ColorU8::from_rgba(blue, green, red, alpha).premultiply();
+                        } else {
+                            *pixel = ColorU8::from_rgba(
+                                ((blue as f32 / 255.) * color_level as f32) as u8,
+                                ((green as f32 / 255.) * color_level as f32) as u8,
+                                ((red as f32 / 255.) * color_level as f32) as u8,
+                                alpha,
+                            )
+                            .premultiply();
+                        }
+                    }
+                }
+                glyphs.push(ShapedGlyph { info, glyph });
+            }
+        }
+
+        self.shaped_title.replace(ShapedTitle {
+            title: self.title.clone(),
+            glyphs,
+            metrics,
+            is_active,
+            dpi: self.font_config.get_dpi(),
+        });
+        Some(())
+    }
+
+    fn draw_title(
+        shaped_title: Option<&ShapedTitle>,
+        canvas: &mut [u8],
+        width: u32,
+        scale: u32,
+        button_count: usize,
+    ) {
+        let Some(shaped) = shaped_title else {
+            return;
+        };
+        let scaled_width = width * scale;
+        let scaled_height = HEADER_SIZE * scale;
+        let Some(mut pixmap) = PixmapMut::from_bytes(canvas, scaled_width, scaled_height) else {
+            return;
+        };
+        let mut x = f64::from(8 * scale);
+        let reserved = (button_count as u32 + 1) * HEADER_SIZE * scale;
+        let limit = scaled_width.saturating_sub(reserved) as f64;
+        let paint = PixmapPaint::default();
+        let baseline =
+            ((f64::from(scaled_height) + shaped.metrics.cell_height.get()) / 2.).round() as i32;
+        let advances = shaped
+            .glyphs
+            .iter()
+            .map(|item| item.info.x_advance.get())
+            .collect::<Vec<_>>();
+        let start = title_tail_start(&advances, (limit - x).max(0.));
+
+        for item in &shaped.glyphs[start..] {
+            if let Some(data) = PixmapRef::from_bytes(
+                &item.glyph.data,
+                item.glyph.width as u32,
+                item.glyph.height as u32,
+            ) {
+                pixmap.draw_pixmap(
+                    (x + item.info.x_offset.get() + item.glyph.bearing_x.get()) as i32,
+                    baseline
+                        + (shaped.metrics.descender - (item.info.y_offset + item.glyph.bearing_y))
+                            .get() as i32,
+                    data,
+                    &paint,
+                    Transform::identity(),
+                    None,
+                );
+            }
+
+            x += item.info.x_advance.get();
+            if x >= limit {
+                break;
+            }
+        }
     }
 
     fn supported_buttons(wm_capabilities: WindowManagerCapabilities) -> [Option<UIButton>; 3] {
@@ -384,6 +575,11 @@ where
     fn set_resizable(&mut self, _resizable: bool) {}
 
     fn draw(&mut self) -> bool {
+        if self.render_data.is_none() {
+            return false;
+        }
+        let is_active = self.state.contains(WindowState::ACTIVATED);
+        self.reshape_title(is_active);
         let render_data = match self.render_data.as_mut() {
             Some(render_data) => render_data,
             None => return false,
@@ -398,7 +594,6 @@ where
             return should_sync;
         }
 
-        let is_active = self.state.contains(WindowState::ACTIVATED);
         let fill_color = if is_active {
             PRIMARY_COLOR_ACTIVE
         } else {
@@ -423,6 +618,13 @@ where
             pixel.copy_from_slice(&fill_color);
         }
 
+        Self::draw_title(
+            self.shaped_title.as_ref(),
+            canvas,
+            width,
+            scale as u32,
+            self.buttons.iter().flatten().count(),
+        );
         Self::draw_buttons(
             &self.buttons,
             canvas,
@@ -460,7 +662,14 @@ where
         should_sync
     }
 
-    fn set_title(&mut self, _title: impl Into<String>) {}
+    fn set_title(&mut self, title: impl Into<String>) {
+        let title = title.into();
+        if self.title != title {
+            self.title = title;
+            self.shaped_title.take();
+            self.dirty = true;
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -527,5 +736,17 @@ enum UIButton {
     Close,
     Maximize,
     Minimize,
+}
+
+#[cfg(test)]
+mod test {
+    use super::title_tail_start;
+
+    #[test]
+    fn title_overflow_keeps_the_trailing_glyphs() {
+        assert_eq!(title_tail_start(&[4., 4., 4., 4.], 16.), 0);
+        assert_eq!(title_tail_start(&[4., 4., 4., 4.], 9.), 2);
+        assert_eq!(title_tail_start(&[12., 4.], 4.), 1);
+    }
 }
 // --- end weezterm remote features ---

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -281,9 +281,13 @@ impl WaylandWindow {
             let wayland_state = &conn.wayland_state.borrow();
             let shm = &wayland_state.shm;
             let subcompositor = wayland_state.subcompositor.clone();
-            TitleBarFrame::new(&window, shm, subcompositor, qh.clone())
+            // --- weezterm remote features ---
+            TitleBarFrame::new(&window, shm, subcompositor, qh.clone(), _font_config)
                 .expect("failed to create csd frame")
+            // --- end weezterm remote features ---
         };
+        // --- weezterm remote features ---
+        window_frame.set_title(name.to_string());
         let hidden = match decor_mode {
             Some(DecorationMode::Client) => false,
             _ => true,
@@ -1169,6 +1173,8 @@ impl WaylandWindowInner {
         if let Some(window) = self.window.as_ref() {
             window.set_title(title.clone());
         }
+        // --- weezterm remote features ---
+        self.window_frame.set_title(title.clone());
         self.refresh_frame();
         self.title = Some(title);
     }


### PR DESCRIPTION
## Summary
- render the active tab's latest title with a trusted d2b identity suffix, including visible Wayland client-side title text
- route d2b-bound new-tab dropdowns to generated creation and detached current-target sessions only
- add a reproducible headless Weston + nested Niri title screenshot harness

## Validation
- `cargo check -p window -p mux -p wezterm-gui`
- `cargo test -p window -p mux -p wezterm-gui`
- `nix flake check --no-write-lock-file`
- ShellCheck and Niri config validation
- owned-compositor screenshot/OCR flow covering background updates, repeated tab switches, and a padded spoof title with the trusted suffix preserved
- end-of-wave panel: 10/10 sign-off
