### PR TITLE
fix: align d2b shell attach timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The new-tab dropdown in a d2b-bound window now offers only immediate shell
   creation and detached shells from the current target; regular windows retain
   the generic launcher.
+- Allowed native d2b shell management operations enough time to complete the
+  daemon's guest-control health and attach path instead of aborting functional
+  VM shells at the generic two-second socket I/O deadline.
 
 ## [0.7.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The new-tab dropdown in a d2b-bound window now offers only immediate shell
   creation and detached shells from the current target; regular windows retain
   the generic launcher.
-- Allowed native d2b shell management operations enough time to complete the
-  daemon's guest-control health and attach path instead of aborting functional
-  VM shells at the generic two-second socket I/O deadline.
+- Allowed native d2b shell attachment enough time to complete the daemon's
+  guest-control health path instead of aborting functional VM shells at the
+  generic two-second socket I/O deadline, while keeping discovery and teardown
+  fail-fast.
 
 ## [0.7.0] - 2026-07-11
 

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -693,6 +693,7 @@ mod imp {
         pub connect_timeout: Duration,
         pub write_timeout: Duration,
         pub read_timeout: Duration,
+        pub shell_management_timeout: Duration,
         pub command_queue_depth: usize,
         pub event_queue_depth: usize,
         pub output_read_max: u64,
@@ -706,6 +707,7 @@ mod imp {
                 connect_timeout: Duration::from_secs(2),
                 write_timeout: Duration::from_secs(2),
                 read_timeout: Duration::from_secs(2),
+                shell_management_timeout: Duration::from_secs(15),
                 command_queue_depth: DEFAULT_QUEUE_DEPTH,
                 event_queue_depth: DEFAULT_EVENT_DEPTH,
                 output_read_max: DEFAULT_READ_MAX,
@@ -1105,7 +1107,7 @@ mod imp {
                 let result = client_op(
                     "listing d2b shells",
                     None,
-                    self.config.write_timeout,
+                    self.config.shell_management_timeout,
                     client.shell_list(status.target().to_string()),
                 )
                 .await?;
@@ -1160,7 +1162,7 @@ mod imp {
                 let shell = client_op(
                     "attaching d2b shell",
                     None,
-                    self.config.write_timeout,
+                    self.config.shell_management_timeout,
                     client.attach_shell(status.target().to_string(), name, false, size),
                 )
                 .await?;
@@ -1394,7 +1396,7 @@ mod imp {
                     let _ = client_op(
                         "closing d2b shell attach",
                         Some(correlation_id.clone()),
-                        config.write_timeout,
+                        config.shell_management_timeout,
                         shell.close_attach(),
                     )
                     .await;
@@ -1407,7 +1409,7 @@ mod imp {
                 let _ = client_op(
                     "closing detached d2b shell",
                     Some(correlation_id.clone()),
-                    config.write_timeout,
+                    config.shell_management_timeout,
                     shell.close_attach(),
                 )
                 .await;
@@ -2260,6 +2262,14 @@ mod imp {
                 session_id: Some("session-1".to_string()),
                 size: size(),
             })
+        }
+
+        #[test]
+        fn shell_management_timeout_covers_daemon_guest_control_budget() {
+            let config = D2bRuntimeConfig::default();
+            assert_eq!(config.shell_management_timeout, Duration::from_secs(15));
+            assert!(config.shell_management_timeout > config.read_timeout);
+            assert!(config.shell_management_timeout > config.write_timeout);
         }
 
         #[test]

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -693,7 +693,7 @@ mod imp {
         pub connect_timeout: Duration,
         pub write_timeout: Duration,
         pub read_timeout: Duration,
-        pub shell_management_timeout: Duration,
+        pub shell_attach_timeout: Duration,
         pub command_queue_depth: usize,
         pub event_queue_depth: usize,
         pub output_read_max: u64,
@@ -707,7 +707,7 @@ mod imp {
                 connect_timeout: Duration::from_secs(2),
                 write_timeout: Duration::from_secs(2),
                 read_timeout: Duration::from_secs(2),
-                shell_management_timeout: Duration::from_secs(15),
+                shell_attach_timeout: Duration::from_secs(15),
                 command_queue_depth: DEFAULT_QUEUE_DEPTH,
                 event_queue_depth: DEFAULT_EVENT_DEPTH,
                 output_read_max: DEFAULT_READ_MAX,
@@ -1107,7 +1107,7 @@ mod imp {
                 let result = client_op(
                     "listing d2b shells",
                     None,
-                    self.config.shell_management_timeout,
+                    self.config.write_timeout,
                     client.shell_list(status.target().to_string()),
                 )
                 .await?;
@@ -1162,7 +1162,7 @@ mod imp {
                 let shell = client_op(
                     "attaching d2b shell",
                     None,
-                    self.config.shell_management_timeout,
+                    self.config.shell_attach_timeout,
                     client.attach_shell(status.target().to_string(), name, false, size),
                 )
                 .await?;
@@ -1396,7 +1396,7 @@ mod imp {
                     let _ = client_op(
                         "closing d2b shell attach",
                         Some(correlation_id.clone()),
-                        config.shell_management_timeout,
+                        config.write_timeout,
                         shell.close_attach(),
                     )
                     .await;
@@ -1409,7 +1409,7 @@ mod imp {
                 let _ = client_op(
                     "closing detached d2b shell",
                     Some(correlation_id.clone()),
-                    config.shell_management_timeout,
+                    config.write_timeout,
                     shell.close_attach(),
                 )
                 .await;
@@ -2265,11 +2265,11 @@ mod imp {
         }
 
         #[test]
-        fn shell_management_timeout_covers_daemon_guest_control_budget() {
+        fn shell_attach_timeout_covers_daemon_guest_control_budget() {
             let config = D2bRuntimeConfig::default();
-            assert_eq!(config.shell_management_timeout, Duration::from_secs(15));
-            assert!(config.shell_management_timeout > config.read_timeout);
-            assert!(config.shell_management_timeout > config.write_timeout);
+            assert_eq!(config.shell_attach_timeout, Duration::from_secs(15));
+            assert!(config.shell_attach_timeout > config.read_timeout);
+            assert!(config.shell_attach_timeout > config.write_timeout);
         }
 
         #[test]


### PR DESCRIPTION
## Change
- add a dedicated 15-second timeout for native d2b shell attachment
- retain two-second fail-fast deadlines for discovery, teardown, and steady-state terminal I/O
- cover the attach timeout contract and document the fix

## Validation
- `nix develop -c cargo test -p mux d2b::imp::test`
- `nix develop -c cargo fmt --all -- --check`
- `nix build .`

## Review
- full ten-role panel reached unanimous 10/10 signoff after narrowing the extended budget to attachment only
