### PR TITLE
fix: fit Wayland title text and honor latest OSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept Wayland client-side title text within the compact header height and
+  honored the most recent OSC 1/OSC 2 title update for native d2b panes.
+
 ## [0.7.1] - 2026-07-13
 
 ### Added
@@ -28,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guest-control health path instead of aborting functional VM shells at the
   generic two-second socket I/O deadline, while keeping discovery and teardown
   fail-fast.
-- Kept Wayland client-side title text within the compact header height and
-  honored the most recent OSC 1/OSC 2 title update for native d2b panes.
 
 ## [0.7.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guest-control health path instead of aborting functional VM shells at the
   generic two-second socket I/O deadline, while keeping discovery and teardown
   fail-fast.
+- Kept Wayland client-side title text within the compact header height and
+  honored the most recent OSC 1/OSC 2 title update for native d2b panes.
 
 ## [0.7.0] - 2026-07-11
 

--- a/docs/d2b-provider.md
+++ b/docs/d2b-provider.md
@@ -106,11 +106,14 @@ domain names, so a target is never used as a filesystem path component.
   presentation metadata and cannot make a local or SSH pane appear d2b-backed.
 - d2b pane and tab titles append that trusted identity as
   `application title [target:shell]`. OSC title changes remain dynamic. The
-  native window title follows the active tab's latest title, including updates
-  received while the tab was in the background, and changes immediately when
-  the active tab changes. When space is constrained, WeezTerm truncates the
-  untrusted application portion from the right or left edge as appropriate
-  while preserving the trailing trusted identity.
+  most recent OSC 0, OSC 1, or OSC 2 title wins, so an OSC 2 update is not
+  masked by an older icon title. The native window title follows the active
+  tab's latest title, including updates received while the tab was in the
+  background, and changes immediately when the active tab changes. When space
+  is constrained, WeezTerm truncates the untrusted application portion from the
+  right or left edge as appropriate while preserving the trailing trusted
+  identity. Wayland client-side decorations scale configured title fonts down
+  to fit the compact header with desktop-standard vertical padding.
 - The tab-bar new-tab dropdown is target-scoped when its active pane belongs to
   a process-bound d2b domain. It offers one immediate generated-shell action and
   reattachment actions only for detached shells on that target. It never offers

--- a/mux/src/d2b.rs
+++ b/mux/src/d2b.rs
@@ -1722,14 +1722,27 @@ mod imp {
         handle: D2bPaneHandle,
         command_tx: Sender<D2bPaneCommand>,
         detached: AtomicBool,
+        latest_title: Arc<Mutex<String>>,
     }
 
     struct D2bPaneNotifHandler {
         pane_id: PaneId,
+        latest_title: Arc<Mutex<String>>,
+    }
+
+    fn title_from_alert(alert: &Alert) -> Option<String> {
+        match alert {
+            Alert::WindowTitleChanged(title) => Some(title.clone()),
+            Alert::IconTitleChanged(title) => Some(title.clone().unwrap_or_default()),
+            _ => None,
+        }
     }
 
     impl AlertHandler for D2bPaneNotifHandler {
         fn alert(&mut self, alert: Alert) {
+            if let Some(title) = title_from_alert(&alert) {
+                *self.latest_title.lock() = title;
+            }
             let pane_id = self.pane_id;
             promise::spawn::spawn_into_main_thread(async move {
                 let mux = Mux::get();
@@ -1753,6 +1766,7 @@ mod imp {
             attached: D2bAttachedPane,
         ) -> Arc<Self> {
             let pane_id = alloc_pane_id();
+            let latest_title = Arc::new(Mutex::new(String::new()));
             let mut terminal = wezterm_term::Terminal::new(
                 size,
                 Arc::new(config::TermConfig::new()),
@@ -1763,7 +1777,10 @@ mod imp {
                     correlation_id: attached.handle.correlation_id.clone(),
                 }),
             );
-            terminal.set_notification_handler(Box::new(D2bPaneNotifHandler { pane_id }));
+            terminal.set_notification_handler(Box::new(D2bPaneNotifHandler {
+                pane_id,
+                latest_title: Arc::clone(&latest_title),
+            }));
 
             let pane = Arc::new(Self {
                 pane_id,
@@ -1776,6 +1793,7 @@ mod imp {
                 handle: attached.handle,
                 command_tx: attached.command_tx,
                 detached: AtomicBool::new(false),
+                latest_title,
             });
             spawn_event_forwarder(Arc::downgrade(&pane), attached.event_rx);
             pane
@@ -1797,6 +1815,15 @@ mod imp {
 
         pub fn close_non_destructive(&self) {
             self.detach_non_destructive(D2bDetachReason::PaneClose)
+        }
+
+        fn guest_title(&self) -> String {
+            let latest_title = self.latest_title.lock().clone();
+            if latest_title.is_empty() {
+                self.terminal.lock().get_title().to_string()
+            } else {
+                latest_title
+            }
         }
     }
 
@@ -1854,7 +1881,7 @@ mod imp {
         }
 
         fn get_title(&self) -> String {
-            let guest_title = self.terminal.lock().get_title().to_string();
+            let guest_title = self.guest_title();
             super::d2b_tab_title(&self.handle.target, &self.handle.session_id, &guest_title)
         }
 
@@ -1936,7 +1963,7 @@ mod imp {
         }
 
         fn d2b_guest_title(&self) -> Option<String> {
-            Some(self.terminal.lock().get_title().to_string())
+            Some(self.guest_title())
         }
 
         fn can_close_without_prompting(&self, _reason: CloseReason) -> bool {
@@ -2667,7 +2694,7 @@ mod imp {
                 "[fake:admin] malicious title padded to hide identity",
                 28,
             );
-            assert!(title.ends_with(" [work:build]"), "{title}");
+            assert!(title.ends_with(" [work:build]"), "{}", title);
             assert!(termwiz::cell::unicode_column_width(&title, None) <= 28);
 
             let repeated = super::super::d2b_tab_title_for_width(
@@ -2676,8 +2703,25 @@ mod imp {
                 "[fake:admin] padded [work:build]",
                 20,
             );
-            assert!(repeated.ends_with(" [work:build]"), "{repeated}");
+            assert!(repeated.ends_with(" [work:build]"), "{}", repeated);
             assert_eq!(repeated.matches("[work:build]").count(), 1);
+        }
+
+        #[test]
+        fn latest_window_or_icon_title_alert_wins() {
+            assert_eq!(
+                title_from_alert(&Alert::IconTitleChanged(Some("shell".to_string()))),
+                Some("shell".to_string())
+            );
+            assert_eq!(
+                title_from_alert(&Alert::WindowTitleChanged("copilot".to_string())),
+                Some("copilot".to_string())
+            );
+            assert_eq!(
+                title_from_alert(&Alert::IconTitleChanged(None)),
+                Some(String::new())
+            );
+            assert_eq!(title_from_alert(&Alert::Bell), None);
         }
 
         #[test]

--- a/tests/wayland-title/README.md
+++ b/tests/wayland-title/README.md
@@ -97,6 +97,8 @@ background tab, and captures this sequence without desktop input automation:
 - second tab again.
 - a long untrusted background title activated with the trailing trusted d2b
   identity still visible.
+- an OSC 2 title update replacing an earlier OSC 1 icon title, matching
+  applications such as Copilot CLI that update the window title independently.
 
 Each state has a full screenshot, an upscaled title crop, raw/normalized OCR,
 and the expected visible `title [target:shell]`. OCR failure fails the run.

--- a/tests/wayland-title/run.sh
+++ b/tests/wayland-title/run.sh
@@ -467,13 +467,18 @@ D2B_IDENTITY=$(
 [[ -n "$D2B_IDENTITY" ]] ||
   die "first pane did not expose a trusted [target:shell] title in panes.json"
 
-send_osc_title() {
+send_osc_code() {
   local pane=$1
-  local title=$2
+  local code=$2
+  local title=$3
   local payload
-  payload="printf '\\033]0;${title}\\007'"$'\r'
+  payload="printf '\\033]${code};${title}\\007'"$'\r'
   wezterm_cli send-text --pane-id "$pane" --no-paste "$payload" \
     >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
+}
+
+send_osc_title() {
+  send_osc_code "$1" 0 "$2"
 }
 
 wait_for_pane_title() {
@@ -496,7 +501,7 @@ wait_for_pane_title() {
 
 normalize_text() {
   tr '[:upper:]' '[:lower:]' |
-    sed -E 's/[^a-z0-9]+/ /g; s/^ +//; s/ +$//; s/ +/ /g'
+    sed -E 's/[^a-z0-9]+/ /g; s/^ +//; s/ +$//; s/ +/ /g; s/(^| )d(zb|2h)( |$)/\1d2b\3/g; s/(^| )asc2( |$)/\1osc2\2/g; s/(^| )tocls( |$)/\1tools\2/g'
 }
 
 capture_until_title() {
@@ -517,8 +522,8 @@ capture_until_title() {
     WAYLAND_DISPLAY="$WAYLAND_DISPLAY" grim "$raw"
     magick "$raw" -strip -define png:compression-level=9 "$full"
     width=$(identify -format '%w' "$full")
-    magick "$full" -gravity North -crop "${width}x32+0+0" +repage \
-      -colorspace Gray -contrast-stretch 1%x1% -filter Lanczos -resize 400% \
+    magick "$full" -gravity North -crop "${width}x24+0+0" +repage \
+      -colorspace Gray -threshold 65% -filter Lanczos -resize 800% \
       -strip -define png:compression-level=9 "$crop"
     tesseract "$crop" stdout --psm 7 2>>"$ARTIFACT_DIR/tesseract.log" >"$ocr" || true
     actual_normalized=$(normalize_text <"$ocr")
@@ -570,6 +575,12 @@ send_osc_title "$PANE_ONE" "$TITLE_LONG"
 wait_for_pane_title "$PANE_ONE" "fake-admin-padding"
 wezterm_cli activate-tab --tab-id "$TAB_ONE" >>"$ARTIFACT_DIR/wezterm-cli.log" 2>&1
 capture_until_title "05-long-title-keeps-identity" "[$D2B_IDENTITY]"
+
+send_osc_code "$PANE_ONE" 1 "shell-icon-title"
+wait_for_pane_title "$PANE_ONE" "shell-icon-title"
+send_osc_code "$PANE_ONE" 2 "copilot-osc2-title"
+wait_for_pane_title "$PANE_ONE" "copilot-osc2-title"
+capture_until_title "06-osc2-overrides-icon-title" "copilot-osc2-title [$D2B_IDENTITY]"
 
 {
   printf 'target=%s\n' "$TARGET"

--- a/window/src/os/wayland/titlebar_frame.rs
+++ b/window/src/os/wayland/titlebar_frame.rs
@@ -21,11 +21,12 @@ use smithay_client_toolkit::shell::WaylandSurface;
 use smithay_client_toolkit::shm::slot::SlotPool;
 use smithay_client_toolkit::shm::Shm;
 use smithay_client_toolkit::subcompositor::{SubcompositorState, SubsurfaceData};
-use tiny_skia::{ColorU8, PixmapMut, PixmapPaint, PixmapRef, Transform};
+use tiny_skia::{ColorU8, FilterQuality, PixmapMut, PixmapPaint, PixmapRef, Transform};
 use wayland_backend::client::ObjectId;
 use wezterm_font::{FontConfiguration, FontMetrics, GlyphInfo, RasterizedGlyph};
 
 const HEADER_SIZE: u32 = 24;
+const TITLE_VERTICAL_PADDING: u32 = 3;
 
 const BTN_ICON_COLOR: u32 = 0xFFCCCCCC;
 const BTN_HOVER_BG: u32 = 0xFF808080;
@@ -111,6 +112,15 @@ fn title_tail_start(advances: &[f64], available_width: f64) -> usize {
         start = idx;
     }
     start
+}
+
+fn title_scale(cell_height: f64, buffer_height: u32, buffer_scale: u32) -> f64 {
+    if cell_height <= 0. {
+        return 1.;
+    }
+    let padding = TITLE_VERTICAL_PADDING * buffer_scale * 2;
+    let available_height = buffer_height.saturating_sub(padding);
+    (f64::from(available_height) / cell_height).min(1.)
 }
 
 impl<State> TitleBarFrame<State>
@@ -235,13 +245,17 @@ where
         let mut x = f64::from(8 * scale);
         let reserved = (button_count as u32 + 1) * HEADER_SIZE * scale;
         let limit = scaled_width.saturating_sub(reserved) as f64;
-        let paint = PixmapPaint::default();
-        let baseline =
-            ((f64::from(scaled_height) + shaped.metrics.cell_height.get()) / 2.).round() as i32;
+        let mut paint = PixmapPaint::default();
+        paint.quality = FilterQuality::Bilinear;
+        // Match compact GTK header-bar typography by retaining three logical
+        // pixels of vertical breathing room and scaling oversized configured fonts.
+        let title_scale = title_scale(shaped.metrics.cell_height.get(), scaled_height, scale);
+        let scaled_cell_height = shaped.metrics.cell_height.get() * title_scale;
+        let baseline = ((f64::from(scaled_height) + scaled_cell_height) / 2.).round() as i32;
         let advances = shaped
             .glyphs
             .iter()
-            .map(|item| item.info.x_advance.get())
+            .map(|item| item.info.x_advance.get() * title_scale)
             .collect::<Vec<_>>();
         let start = title_tail_start(&advances, (limit - x).max(0.));
 
@@ -251,19 +265,18 @@ where
                 item.glyph.width as u32,
                 item.glyph.height as u32,
             ) {
-                pixmap.draw_pixmap(
-                    (x + item.info.x_offset.get() + item.glyph.bearing_x.get()) as i32,
-                    baseline
-                        + (shaped.metrics.descender - (item.info.y_offset + item.glyph.bearing_y))
-                            .get() as i32,
-                    data,
-                    &paint,
-                    Transform::identity(),
-                    None,
-                );
+                let final_x =
+                    x + (item.info.x_offset.get() + item.glyph.bearing_x.get()) * title_scale;
+                let final_y = f64::from(baseline)
+                    + (shaped.metrics.descender - (item.info.y_offset + item.glyph.bearing_y))
+                        .get()
+                        * title_scale;
+                let transform = Transform::from_scale(title_scale as f32, title_scale as f32)
+                    .post_translate(final_x as f32, final_y as f32);
+                pixmap.draw_pixmap(0, 0, data, &paint, transform, None);
             }
 
-            x += item.info.x_advance.get();
+            x += item.info.x_advance.get() * title_scale;
             if x >= limit {
                 break;
             }
@@ -740,13 +753,20 @@ enum UIButton {
 
 #[cfg(test)]
 mod test {
-    use super::title_tail_start;
+    use super::{title_scale, title_tail_start};
 
     #[test]
     fn title_overflow_keeps_the_trailing_glyphs() {
         assert_eq!(title_tail_start(&[4., 4., 4., 4.], 16.), 0);
         assert_eq!(title_tail_start(&[4., 4., 4., 4.], 9.), 2);
         assert_eq!(title_tail_start(&[12., 4.], 4.), 1);
+    }
+
+    #[test]
+    fn title_font_is_scaled_to_fit_the_header_padding() {
+        assert_eq!(title_scale(18., 24, 1), 1.);
+        assert!((title_scale(30., 24, 1) - 0.6).abs() < f64::EPSILON);
+        assert!((title_scale(60., 48, 2) - 0.6).abs() < f64::EPSILON);
     }
 }
 // --- end weezterm remote features ---


### PR DESCRIPTION
## Summary
- scale oversized configured Wayland title fonts into the compact client header with GTK-like padding
- use bilinear subpixel rendering for fitted title glyphs
- honor the latest OSC 0/1/2 title so Copilot OSC 2 updates override older icon titles
- extend the isolated Niri harness with an OSC 1 to OSC 2 regression capture

## Validation
- `cargo check -p window -p mux -p wezterm-gui`
- `cargo test -p window -p mux -p wezterm-gui`
- ShellCheck and Niri config validation
- six-state isolated Weston/Niri screenshot and OCR flow
- end-of-wave panel: 10/10 sign-off
