### PR TITLE
chore: release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-07-13
+
 ### Fixed
 
 - Kept Wayland client-side title text within the compact header height and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7374,7 +7374,7 @@ dependencies = [
 
 [[package]]
 name = "wezterm-version"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "git2",
 ]

--- a/docs/d2b-provider.md
+++ b/docs/d2b-provider.md
@@ -21,7 +21,7 @@ Pin WeezTerm and d2b to one `nixpkgs` revision:
     };
 
     weezterm = {
-      url = "github:vicondoa/weezterm/v0.7.1";
+      url = "github:vicondoa/weezterm/v0.7.2";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -200,7 +200,7 @@
           # --- end weezterm remote features ---
           src = ./..;
           # --- weezterm remote features ---
-          version = "0.7.1";
+          version = "0.7.2";
 
           cargoLock = {
             lockFile = ../Cargo.lock;

--- a/wezterm-version/Cargo.toml
+++ b/wezterm-version/Cargo.toml
@@ -3,7 +3,7 @@ name = "wezterm-version"
 # --- weezterm remote features ---
 # This is the single source of truth for the WeezTerm version.
 # Dev builds append "-dev.YYYYMMDD.HASH"; tagged release builds use this as-is.
-version = "0.7.1"
+version = "0.7.2"
 # --- end weezterm remote features ---
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
## Summary
- release WeezTerm 0.7.2
- publish compact Wayland title-font fitting
- publish latest OSC 0/1/2 title handling for d2b panes

## Validation
- `bash scripts/changelog-check.sh CHANGELOG.md`
- `cargo fmt --all -- --check`
- `cargo check -p wezterm-version`
- `nix flake check --no-write-lock-file`
